### PR TITLE
Fix library not found on linux

### DIFF
--- a/python/libgdf_cffi/__init__.py
+++ b/python/libgdf_cffi/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
-import os, sys
+import os
+import sys
 
 from .wrapper import _libgdf_wrapper
 from .wrapper import GDFError           # re-exported
@@ -14,10 +15,17 @@ else:
         if os.name == 'posix':
             # TODO this will need to be changed when packaged for distribution
             if sys.platform == 'darwin':
-                return './libgdf.dylib'
+                path = 'libgdf.dylib'
             else:
-                return './libgdf.so'
-        raise NotImplementedError('OS {} not supported'.format(os.name))
+                path = 'libgdf.so'
+        else:
+            raise NotImplementedError('OS {} not supported'.format(os.name))
+        # Prefer local version of the library if it exists
+        localpath = os.path.join('.', path)
+        if os.path.isfile(localpath):
+            return localpath
+        else:
+            return path
 
     libgdf_api = ffi.dlopen(_get_lib_name())
     libgdf = _libgdf_wrapper(ffi, libgdf_api)


### PR DESCRIPTION
The local path prefix (e.g. `./`) is taken more strictly on Linux than OSX.  As a result, it prevents looking into the conda environment for the `libgdf.so`.

The problem is not affecting osx.

