### PR TITLE
Fix incorrect identity value for max-reduce

### DIFF
--- a/python/tests/test_reductions.py
+++ b/python/tests/test_reductions.py
@@ -45,7 +45,8 @@ def test_sum(dtype, nelem):
     print('expect:', expect)
     print('got:', got)
 
-    np.testing.assert_array_almost_equal_nulp(expect, got, nulp=1)
+    decimal = 4 if dtype == np.float32 else 6
+    np.testing.assert_array_almost_equal(expect, got, decimal=decimal)
 
 
 @pytest.mark.parametrize('dtype,nelem', params)

--- a/python/tests/test_unaryops.py
+++ b/python/tests/test_unaryops.py
@@ -11,8 +11,10 @@ from libgdf_cffi import ffi, libgdf, GDFError
 from .utils import new_column, unwrap_devary, get_dtype, gen_rand
 
 
-def math_op_test(dtype, ulp, expect_fn, test_fn, nelem=128, scale=1):
-    h_data = (gen_rand(dtype, nelem) * scale).astype(dtype)
+def math_op_test(dtype, ulp, expect_fn, test_fn, nelem=128, scale=1,
+                 positive_only=False):
+    randvals = gen_rand(dtype, nelem, positive_only=positive_only)
+    h_data = (randvals * scale).astype(dtype)
     d_data = cuda.to_device(h_data)
     d_result = cuda.device_array_like(d_data)
 
@@ -112,8 +114,8 @@ def test_unsupported_dtype_error():
 
 
 params_real_types = [
-    (np.float64, 2),
-    (np.float32, 3),
+    (np.float64, 3),
+    (np.float32, 4),
 ]
 
 
@@ -158,14 +160,16 @@ def test_exp(dtype, ulp):
 
 @pytest.mark.parametrize('dtype,ulp', params_real_types)
 def test_log(dtype, ulp):
-    math_op_test(dtype, ulp, np.log, libgdf.gdf_log_generic)
+    math_op_test(dtype, ulp, np.log, libgdf.gdf_log_generic,
+                 positive_only=True)
 
 
 # power
 
 @pytest.mark.parametrize('dtype,ulp', params_real_types)
 def test_sqrt(dtype, ulp):
-    math_op_test(dtype, ulp, np.sqrt, libgdf.gdf_sqrt_generic)
+    math_op_test(dtype, ulp, np.sqrt, libgdf.gdf_sqrt_generic,
+                 positive_only=True)
 
 
 # rounding

--- a/python/tests/utils.py
+++ b/python/tests/utils.py
@@ -31,7 +31,11 @@ def seed_rand():
 def gen_rand(dtype, size, **kwargs):
     dtype = np.dtype(dtype)
     if dtype.kind == 'f':
-        return np.random.random(size).astype(dtype)
+        res = np.random.random(size=size).astype(dtype)
+        if kwargs.get('positive_only', False):
+            return res
+        else:
+            return (res * 2 - 1)
     elif dtype.kind == 'i':
         low = kwargs.get('low', -10000)
         high = kwargs.get('high', 10000)

--- a/src/reductions.cu
+++ b/src/reductions.cu
@@ -262,8 +262,8 @@ DEF_REDUCE_IMPL(gdf_min_i8, DeviceMin, int8_t, std::numeric_limits<int8_t>::max(
 /* Max */
 
 DEF_REDUCE_OP_NUM(gdf_max)
-DEF_REDUCE_IMPL(gdf_max_f64, DeviceMax, double, std::numeric_limits<double>::min())
-DEF_REDUCE_IMPL(gdf_max_f32, DeviceMax, float, std::numeric_limits<float>::min())
-DEF_REDUCE_IMPL(gdf_max_i64, DeviceMax, int64_t, std::numeric_limits<int64_t>::min())
-DEF_REDUCE_IMPL(gdf_max_i32, DeviceMax, int32_t, std::numeric_limits<int32_t>::min())
-DEF_REDUCE_IMPL(gdf_max_i8, DeviceMax, int8_t,  std::numeric_limits<int8_t>::min())
+DEF_REDUCE_IMPL(gdf_max_f64, DeviceMax, double, std::numeric_limits<double>::lowest())
+DEF_REDUCE_IMPL(gdf_max_f32, DeviceMax, float, std::numeric_limits<float>::lowest())
+DEF_REDUCE_IMPL(gdf_max_i64, DeviceMax, int64_t, std::numeric_limits<int64_t>::lowest())
+DEF_REDUCE_IMPL(gdf_max_i32, DeviceMax, int32_t, std::numeric_limits<int32_t>::lowest())
+DEF_REDUCE_IMPL(gdf_max_i8, DeviceMax, int8_t,  std::numeric_limits<int8_t>::lowest())


### PR DESCRIPTION
* rng for tests is updated to give negative floats.
* error tolerance is increased for some tests.