### PR TITLE
Fix build. Ensure struct gdf_dtype_extra_info is C compatible

### DIFF
--- a/include/gdf/cffi/types.h
+++ b/include/gdf/cffi/types.h
@@ -35,10 +35,10 @@ typedef enum {
 	TIME_UNIT_ns   // nanosecond
 } gdf_time_unit;
 
-struct gdf_dtype_extra_info {
+typedef struct {
 	gdf_time_unit time_unit;
 	// here we can also hold info for decimal datatype or any other datatype that requires additional information
-};
+} gdf_dtype_extra_info;
 
 typedef struct gdf_column_{
     void *data;


### PR DESCRIPTION
PR #47 broke the build due to error with cffi.  This patch fixes it.