### PR TITLE
Update TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,12 @@ env:
 
 matrix:
   include:
-    - env: CUDA=8.0.61-1
     - env: CUDA=9.0.176_384.81
     - env: CUDA=9.1.85_387.26
-    - env: CUDA=8.0.61-1 BUILD_CFFI=1 PYTHON=3.6
-    - env: CUDA=8.0.61-1 BUILD_CFFI=1 PYTHON=3.5
-    - env: CUDA=8.0.61-1 BUILD_CFFI=1 PYTHON=2.7
+    - env: CUDA=9.1.85_387.26 BUILD_CFFI=1 PYTHON=3.6
+    - env: CUDA=9.0.176_384.81 BUILD_CFFI=1 PYTHON=3.6
+    - env: CUDA=9.0.176_384.81 BUILD_CFFI=1 PYTHON=3.5
+    - env: CUDA=9.0.176_384.81 BUILD_CFFI=1 PYTHON=2.7
 
 before_install:
   - source ./travisci/install-cuda-trusty.sh


### PR DESCRIPTION
Since running on Volta is of interest and it requires CUDA >= 9, we should drop building CUDA8 in the CI and provide both CUDA9.0 and CUDA9.1 builds for python3.6.  

These dev builds are available on https://anaconda.org/gpuopenanalytics/libgdf/files; e.g. 

```bash
conda install -c conda-forge -c gpuopenanalytics/label/dev -c numba libgdf libgdf_cffi cudatoolkit=9.1
```