### PR TITLE
[REVIEW] Fix warnings in sqls CUDA files

### DIFF
--- a/include/sqls_rtti_comp.hpp
+++ b/include/sqls_rtti_comp.hpp
@@ -151,7 +151,7 @@ struct LesserRTTI
 		     IndexT row,
 		     const void* const * columns)
   {
-    return (static_cast<const ColType* const>(columns[col_index]))[row];
+    return (static_cast<const ColType*>(columns[col_index]))[row];
   }
   
 private:
@@ -262,7 +262,7 @@ private:
 		      const void* const * columns,
 		      ColType )
     {
-      const ColType* const d_in = static_cast<const ColType* const>(columns[col_index]);
+      const ColType* const d_in = static_cast<const ColType*>(columns[col_index]);
       ColType* d_out = static_cast<ColType*>(d_cols_out_[col_index]);
       thrust::gather(thrust::device,
 		     d_indices_, d_indices_ + nrows_new_, //map of indices
@@ -287,42 +287,42 @@ private:
 	{
 	  using ColType = int8_t;//char;
 	  
-	  ColType dummy;
+	  ColType dummy=0;
 	  return pred(col_index, columns_, dummy);
 	}
       case GDF_INT16:
 	{
 	  using ColType = int16_t;//short;
 
-	  ColType dummy;
+	  ColType dummy=0;
 	  return pred(col_index, columns_, dummy);
 	}
       case GDF_INT32:
 	{
 	  using ColType = int32_t;//int;
 
-	  ColType dummy;
+	  ColType dummy=0;
 	  return pred(col_index, columns_, dummy);
 	}
       case GDF_INT64:
 	{
 	  using ColType = int64_t;//long;
 
-	  ColType dummy;
+	  ColType dummy=0;
 	  return pred(col_index, columns_, dummy);
 	}
       case GDF_FLOAT32:
 	{
 	  using ColType = float;
 
-	  ColType dummy;
+	  ColType dummy=0;
 	  return pred(col_index, columns_, dummy);
 	}
       case GDF_FLOAT64:
 	{
 	  using ColType = double;
 
-	  ColType dummy;
+	  ColType dummy=0;
 	  return pred(col_index, columns_, dummy);
 	}
 

--- a/src/sqls_ops.cu
+++ b/src/sqls_ops.cu
@@ -195,6 +195,7 @@ namespace{ //annonymus
       default:
         assert( false );//type not handled
       }
+      return 0;
   }
 
 #ifdef DEBUG_
@@ -1272,7 +1273,7 @@ gdf_error gdf_group_by_count(int ncols,                    // # columns
                              gdf_context* ctxt)            //struct with additional info: bool is_sorted, flag_sort_or_hash, bool flag_count_distinct
 {
   if( ctxt->flag_distinct )
-    gdf_group_by_single(ncols, cols, col_agg, out_col_indices, out_col_values, out_col_agg, ctxt, GDF_COUNT_DISTINCT);
+    return gdf_group_by_single(ncols, cols, col_agg, out_col_indices, out_col_values, out_col_agg, ctxt, GDF_COUNT_DISTINCT);
   else
     return gdf_group_by_single(ncols, cols, col_agg, out_col_indices, out_col_values, out_col_agg, ctxt, GDF_COUNT);
 }

--- a/src/tests/sqls/sqls_g_tester.cu
+++ b/src/tests/sqls/sqls_g_tester.cu
@@ -42,7 +42,7 @@ using Vector = thrust::device_vector<T>;
 using IndexT = size_t;
 
 template<typename T, typename Allocator, template<typename, typename> class Vector>
-__host__ __device__
+__host__ 
 void print_v(const Vector<T, Allocator>& v, std::ostream& os)
 {
   thrust::copy(v.begin(), v.end(), std::ostream_iterator<T>(os,","));
@@ -52,7 +52,7 @@ void print_v(const Vector<T, Allocator>& v, std::ostream& os)
 template<typename T,
 	 typename Allocator,
 	 template<typename, typename> class Vector>
-__host__ __device__
+__host__
 void print_v(const Vector<T, Allocator>& v, typename Vector<T, Allocator>::const_iterator pos, std::ostream& os)
 { 
   thrust::copy(v.begin(), pos, std::ostream_iterator<T>(os,","));//okay
@@ -62,7 +62,7 @@ void print_v(const Vector<T, Allocator>& v, typename Vector<T, Allocator>::const
 template<typename T,
 	 typename Allocator,
 	 template<typename, typename> class Vector>
-__host__ __device__
+__host__
 void print_v(const Vector<T, Allocator>& v, size_t n, std::ostream& os)
 { 
   thrust::copy_n(v.begin(), n, std::ostream_iterator<T>(os,","));//okay
@@ -143,7 +143,7 @@ TEST(gdf_group_by_sum, UsageTestSum)
   c_vout.size = nrows;
 
   size_t n_group = 0;
-  int flag_sorted = 0;
+  //int flag_sorted = 0;
 
   std::cout<<"aggregate = sum on column:\n";
   print_v(dd1, std::cout);
@@ -291,7 +291,7 @@ TEST(gdf_group_by_count, UsageTestCount)
   c_vout.size = nrows;
 
   size_t n_group = 0;
-  int flag_sorted = 0;
+  //int flag_sorted = 0;
 
   std::cout<<"aggregate = count on column:\n";
   print_v(dd1, std::cout);
@@ -437,7 +437,7 @@ TEST(gdf_group_by_avg, UsageTestAvg)
   c_vout.size = nrows;
 
   size_t n_group = 0;
-  int flag_sorted = 0;
+  //int flag_sorted = 0;
 
   std::cout<<"aggregate = avg on column:\n";
   print_v(dd1, std::cout);
@@ -582,7 +582,7 @@ TEST(gdf_group_by_min, UsageTestMin)
   c_vout.size = nrows;
 
   size_t n_group = 0;
-  int flag_sorted = 0;
+  //int flag_sorted = 0;
 
   std::vector<double> v_col{2., 4., 5., 7., 11., 3.};
   thrust::device_vector<double> d_col = v_col;
@@ -733,7 +733,7 @@ TEST(gdf_group_by_max, UsageTestMax)
   c_vout.size = nrows;
 
   size_t n_group = 0;
-  int flag_sorted = 0;
+  //int flag_sorted = 0;
 
   std::vector<double> v_col{2., 4., 5., 7., 11., 3.};
   thrust::device_vector<double> d_col = v_col;


### PR DESCRIPTION
Specifically: initializing dummy variables to zero; removing meaningless const type qualifiers; adding missing return statements; removing `__device__` specifier on function that passes `cout` to a thrust function. 

Note: warnings caused by ModernGPU using shfl rather than shfl_sync persist. This is being handled separately.