### PR TITLE
[REVIEW] Remove pytest-ci option from CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@
 #    $ cmake ..          # configure build system
 #    $ make              # make libgdf
 #    $ make pytest       # trigger test
-#    $ make pytest-ci    # trigger test with jUnit.xml output
 #    $ make install      # install libgdf
 
 PROJECT(libgdf)
@@ -163,12 +162,6 @@ add_custom_target(pytest DEPENDS copy_python)
 add_custom_command(TARGET pytest POST_BUILD
                    COMMAND ${CMAKE_COMMAND} -E env LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${CMAKE_BINARY_DIR} py.test -v
                    WORKING_DIRECTORY --cache-clear tests)
-
-# The test CI target with junit.xml output
-add_custom_target(pytest-ci DEPENDS copy_python)
-add_custom_command(TARGET pytest POST_BUILD
-                   COMMAND ${CMAKE_COMMAND} -E env LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${CMAKE_BINARY_DIR} py.test -v
-                   WORKING_DIRECTORY --cache-clear --junitxml=junit.xml tests)
 
 # The install target
 install(TARGETS gdf LIBRARY DESTINATION lib)


### PR DESCRIPTION
`pytest-ci` option was intended to produce a `junit.xml` file for gpuCI to consume; however, it did not work. Instead of leaving this dead code in the `CMakeLists.txt` I'm removing it.

For gpuCI I am calling `py.test` directly with the flags needed to generate the file in an accessible place to report the results.