### PR TITLE
Hash Join for arbitrary number of columns

### DIFF
--- a/src/gdf_table.cuh
+++ b/src/gdf_table.cuh
@@ -1,0 +1,406 @@
+/*
+ * Copyright (c) 2018, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GDF_TABLE_H
+#define GDF_TABLE_H
+
+#include <gdf/gdf.h>
+#include <thrust/device_vector.h>
+#include <cassert>
+#include "hashmap/hash_functions.cuh"
+#include "hashmap/managed.cuh"
+
+// TODO Inherit from managed class to allocate with managed memory?
+template <typename T>
+class gdf_table : public managed
+{
+public:
+
+  using size_type = T;
+
+  gdf_table(size_type num_cols, gdf_column ** gdf_columns) 
+    : num_columns(num_cols), host_columns(gdf_columns)
+  {
+
+    column_length = host_columns[0]->size;
+
+    // Copy the pointers to the column's data and types to the device 
+    // as contiguous arrays
+    device_columns.reserve(num_cols);
+    device_types.reserve(num_cols);
+    for(size_type i = 0; i < num_cols; ++i)
+    {
+      assert(column_length == host_columns[i]->size);
+
+      device_columns.push_back(host_columns[i]->data);
+      device_types.push_back(host_columns[i]->dtype);
+    }
+
+    d_columns_data = device_columns.data().get();
+    d_columns_types = device_types.data().get();
+  }
+
+  ~gdf_table(){}
+
+  __host__ __device__
+  size_type get_column_length() const
+  {
+    return column_length;
+  }
+
+  gdf_dtype get_build_column_type() const
+  {
+    return host_columns[build_column_index]->dtype;
+  }
+
+  void * get_build_column_data() const
+  {
+    return host_columns[build_column_index]->data;
+  }
+
+  void * get_probe_column_data() const
+  {
+    return host_columns[build_column_index]->data;
+  }
+
+  __host__ 
+  void print_row(const size_type row_index, char * msg = "") const
+  {
+    char row[256];
+    sprintf(row,"(");
+    for(size_type i = 0; i < num_columns; ++i)
+    {
+      const gdf_dtype col_type = d_columns_types[i];
+
+      switch(col_type)
+      {
+        case GDF_INT8:
+          {
+            sprintf(row,"%d", static_cast<int8_t*>(d_columns_data[i])[row_index]);
+            break;
+          }
+        case GDF_INT16:
+          {
+            sprintf(row,"%d", static_cast<int16_t*>(d_columns_data[i])[row_index]);
+            break;
+          }
+        case GDF_INT32:
+          {
+            sprintf(row,"%d", static_cast<int32_t*>(d_columns_data[i])[row_index]);
+            break;
+          }
+        case GDF_INT64:
+          {
+            sprintf(row,"%ld", static_cast<int64_t*>(d_columns_data[i])[row_index]);
+            break;
+          }
+        case GDF_FLOAT32:
+          {
+            sprintf(row,"%f", static_cast<float*>(d_columns_data[i])[row_index]);
+            break;
+          }
+        case GDF_FLOAT64:
+          {
+            sprintf(row,"%f", static_cast<double*>(d_columns_data[i])[row_index]);
+            break;
+          }
+        case GDF_DATE32:
+          {
+            sprintf(row,"%d", static_cast<int32_t*>(d_columns_data[i])[row_index]);
+            break;
+          }
+        case GDF_DATE64:
+          {
+            sprintf(row,"%ld", static_cast<int64_t*>(d_columns_data[i])[row_index]);
+            break;
+          }
+        case GDF_TIMESTAMP:
+          {
+            sprintf(row,"%ld", static_cast<int64_t*>(d_columns_data[i])[row_index]);
+            break;
+          }
+        default:
+          assert(false && "Attempted to compare unsupported GDF datatype");
+      }
+      sprintf(row,", ");
+    }
+    sprintf(row,")\n");
+
+    printf("%s %s", msg, row);
+
+  }
+
+    /* --------------------------------------------------------------------------*/
+    /** 
+     * @Synopsis  Checks for equality between a row in this table and another table.
+     * 
+     * @Param other The other table whose row is compared to this tables
+     * @Param my_row_index The row index of this table to compare
+     * @Param other_row_index The row index of the other table to compare
+     * 
+     * @Returns True if the elements in both rows are equivalent, otherwise False
+     */
+    /* ----------------------------------------------------------------------------*/
+  __device__
+  bool rows_equal(gdf_table const & other, 
+                  const size_type my_row_index, 
+                  const size_type other_row_index) const
+  {
+
+    for(size_type i = 0; i < num_columns; ++i)
+    {
+      const gdf_dtype my_col_type = d_columns_types[i];
+      const gdf_dtype other_col_type = other.d_columns_types[i];
+    
+      if(my_col_type != other_col_type)
+      {
+        printf("Attempted to compare columns of different types.\n");
+        return false;
+      }
+
+      switch(my_col_type)
+      {
+        case GDF_INT8:
+          {
+            using col_type = int8_t;
+            const col_type my_elem = static_cast<col_type*>(d_columns_data[i])[my_row_index];
+            const col_type other_elem = static_cast<col_type*>(other.d_columns_data[i])[other_row_index];
+            if(my_elem != other_elem)
+              return false;
+            break;
+          }
+        case GDF_INT16:
+          {
+            using col_type = int16_t;
+            const col_type my_elem = static_cast<col_type*>(d_columns_data[i])[my_row_index];
+            const col_type other_elem = static_cast<col_type*>(other.d_columns_data[i])[other_row_index];
+            if(my_elem != other_elem)
+              return false;
+            break;
+          }
+        case GDF_INT32:
+          {
+            using col_type = int32_t;
+            const col_type my_elem = static_cast<col_type*>(d_columns_data[i])[my_row_index];
+            const col_type other_elem = static_cast<col_type*>(other.d_columns_data[i])[other_row_index];
+            if(my_elem != other_elem)
+              return false;
+            break;
+          }
+        case GDF_INT64:
+          {
+            using col_type = int64_t;
+            const col_type my_elem = static_cast<col_type*>(d_columns_data[i])[my_row_index];
+            const col_type other_elem = static_cast<col_type*>(other.d_columns_data[i])[other_row_index];
+            if(my_elem != other_elem)
+              return false;
+            break;
+          }
+        case GDF_FLOAT32:
+          {
+            using col_type = float;
+            const col_type my_elem = static_cast<col_type*>(d_columns_data[i])[my_row_index];
+            const col_type other_elem = static_cast<col_type*>(other.d_columns_data[i])[other_row_index];
+            if(my_elem != other_elem)
+              return false;
+            break;
+          }
+        case GDF_FLOAT64:
+          {
+            using col_type = double;
+            const col_type my_elem = static_cast<col_type*>(d_columns_data[i])[my_row_index];
+            const col_type other_elem = static_cast<col_type*>(other.d_columns_data[i])[other_row_index];
+            if(my_elem != other_elem)
+              return false;
+            break;
+          }
+        case GDF_DATE32:
+          {
+            using col_type = int32_t;
+            const col_type my_elem = static_cast<col_type*>(d_columns_data[i])[my_row_index];
+            const col_type other_elem = static_cast<col_type*>(other.d_columns_data[i])[other_row_index];
+            if(my_elem != other_elem)
+              return false;
+            break;
+          }
+        case GDF_DATE64:
+          {
+            using col_type = int64_t;
+            const col_type my_elem = static_cast<col_type*>(d_columns_data[i])[my_row_index];
+            const col_type other_elem = static_cast<col_type*>(other.d_columns_data[i])[other_row_index];
+            if(my_elem != other_elem)
+              return false;
+            break;
+          }
+        case GDF_TIMESTAMP:
+          {
+            using col_type = int64_t;
+            const col_type my_elem = static_cast<col_type*>(d_columns_data[i])[my_row_index];
+            const col_type other_elem = static_cast<col_type*>(other.d_columns_data[i])[other_row_index];
+            if(my_elem != other_elem)
+              return false;
+            break;
+          }
+        default:
+          printf("Attempted to compare columns of unsupported GDF datatype\n");
+          return false;
+      }
+    }
+
+    return true;
+  }
+
+  /* --------------------------------------------------------------------------*/
+  /** 
+   * @Synopsis  This device function computes a hash value for a given row in the table
+   * 
+   * @Param row_index The row of the table to compute the hash value for
+   * @Param num_columns_to_hash The number of columns in the row to hash. If 0, hashes all columns
+   * @tparam hash_function The hash function that is used for each element in the row
+   * @tparam dummy Used only to be able to resolve the result_type from the hash_function.
+                   The actual type of dummy doesn't matter.
+   * 
+   * @Returns The hash value of the row
+   */
+  /* ----------------------------------------------------------------------------*/
+  template <template <typename> class hash_function = default_hash,
+            typename dummy = int>
+  __device__ 
+  typename hash_function<dummy>::result_type hash_row(size_type row_index, 
+                                                      size_type num_columns_to_hash = 0) const
+  {
+    using hash_value_t = typename hash_function<dummy>::result_type;
+    hash_value_t hash_value{0};
+
+    // If num_columns_to_hash is zero, hash all columns
+    if(0 == num_columns_to_hash)
+      num_columns_to_hash = this->num_columns;
+
+    for(size_type i = 0; i < num_columns_to_hash; ++i)
+    {
+      const gdf_dtype current_column_type = d_columns_types[i];
+
+      switch(current_column_type)
+      {
+        case GDF_INT8:
+          {
+            using col_type = int8_t;
+            hash_function<col_type> hasher;
+            const col_type * current_column = static_cast<col_type*>(d_columns_data[i]);
+            const col_type current_value = current_column[row_index];
+            hash_value_t key_hash = hasher(current_value);
+            hash_value = hasher.hash_combine(hash_value, key_hash);
+          }
+        case GDF_INT16:
+          {
+            using col_type = int16_t;
+            hash_function<col_type> hasher;
+            const col_type * current_column = static_cast<col_type*>(d_columns_data[i]);
+            const col_type current_value = current_column[row_index];
+            hash_value_t key_hash = hasher(current_value);
+            hash_value = hasher.hash_combine(hash_value, key_hash);
+          }
+        case GDF_INT32:
+          {
+            using col_type = int32_t;
+            hash_function<col_type> hasher;
+            const col_type * current_column = static_cast<col_type*>(d_columns_data[i]);
+            const col_type current_value = current_column[row_index];
+            hash_value_t key_hash = hasher(current_value);
+            hash_value = hasher.hash_combine(hash_value, key_hash);
+          }
+        case GDF_INT64:
+          {
+            using col_type = int64_t;
+            hash_function<col_type> hasher;
+            const col_type * current_column = static_cast<col_type*>(d_columns_data[i]);
+            const col_type current_value = current_column[row_index];
+            hash_value_t key_hash = hasher(current_value);
+            hash_value = hasher.hash_combine(hash_value, key_hash);
+          }
+        case GDF_FLOAT32:
+          {
+            using col_type = float;
+            hash_function<col_type> hasher;
+            const col_type * current_column = static_cast<col_type*>(d_columns_data[i]);
+            const col_type current_value = current_column[row_index];
+            hash_value_t key_hash = hasher(current_value);
+            hash_value = hasher.hash_combine(hash_value, key_hash);
+          }
+        case GDF_FLOAT64:
+          {
+            using col_type = double;
+            hash_function<col_type> hasher;
+            const col_type * current_column = static_cast<col_type*>(d_columns_data[i]);
+            const col_type current_value = current_column[row_index];
+            hash_value_t key_hash = hasher(current_value);
+            hash_value = hasher.hash_combine(hash_value, key_hash);
+          }
+        case GDF_DATE32:
+          {
+            using col_type = int32_t;
+            hash_function<col_type> hasher;
+            const col_type * current_column = static_cast<col_type*>(d_columns_data[i]);
+            const col_type current_value = current_column[row_index];
+            hash_value_t key_hash = hasher(current_value);
+            hash_value = hasher.hash_combine(hash_value, key_hash);
+          }
+        case GDF_DATE64:
+          {
+            using col_type = int64_t;
+            hash_function<col_type> hasher;
+            const col_type * current_column = static_cast<col_type*>(d_columns_data[i]);
+            const col_type current_value = current_column[row_index];
+            hash_value_t key_hash = hasher(current_value);
+            hash_value = hasher.hash_combine(hash_value, key_hash);
+          }
+        case GDF_TIMESTAMP:
+          {
+            using col_type = int64_t;
+            hash_function<col_type> hasher;
+            const col_type * current_column = static_cast<col_type*>(d_columns_data[i]);
+            const col_type current_value = current_column[row_index];
+            hash_value_t key_hash = hasher(current_value);
+            hash_value = hasher.hash_combine(hash_value, key_hash);
+          }
+        default:
+          assert(false && "Attempted to hash unsupported GDF datatype");
+      }
+    }
+
+    return hash_value;
+  }
+
+
+private:
+
+  void ** d_columns_data{nullptr};
+  gdf_dtype * d_columns_types{nullptr};
+
+  thrust::device_vector<void*> device_columns;
+  thrust::device_vector<gdf_dtype> device_types;
+
+  gdf_column ** host_columns;
+  const size_type num_columns;
+  size_type column_length;
+
+  // Just use the first column as the build/probe column for now
+  const size_type build_column_index{0};
+  const size_type probe_column_index{0};
+
+};
+
+#endif

--- a/src/groupby/groupby.cuh
+++ b/src/groupby/groupby.cuh
@@ -411,8 +411,6 @@ gdf_error gdf_group_by_hash_avg(int ncols,
     case GDF_FLOAT64:{ return multi_pass_avg<double>(ncols, in_groupby_columns, in_aggregation_column, out_groupby_columns, out_aggregation_column);}
     default: return GDF_UNSUPPORTED_DTYPE;
   }
-
-  return GDF_SUCCESS;
 }
 
 

--- a/src/hashmap/concurrent_unordered_multimap.cuh
+++ b/src/hashmap/concurrent_unordered_multimap.cuh
@@ -176,9 +176,9 @@ __global__ void init_hashtbl(
 template <typename T>
 struct equal_to
 {
-    typedef bool result_type;
-    typedef T first_argument_type;
-    typedef T second_argument_type;
+    using result_type = bool;
+    using first_argument_type = T;
+    using second_argument_type = T;
     __forceinline__
     __host__ __device__ constexpr bool operator()(const first_argument_type &lhs, const second_argument_type &rhs) const 
     {
@@ -189,11 +189,11 @@ struct equal_to
 template<typename Iterator>
 class cycle_iterator_adapter {
 public:
-    typedef typename std::iterator_traits<Iterator>::value_type         value_type; 
-    typedef typename std::iterator_traits<Iterator>::difference_type    difference_type;
-    typedef typename std::iterator_traits<Iterator>::pointer            pointer;
-    typedef typename std::iterator_traits<Iterator>::reference          reference;
-    typedef Iterator                                                    iterator_type;
+    using value_type = typename std::iterator_traits<Iterator>::value_type; 
+    using difference_type = typename std::iterator_traits<Iterator>::difference_type;
+    using pointer = typename std::iterator_traits<Iterator>::pointer;
+    using reference = typename std::iterator_traits<Iterator>::reference;
+    using iterator_type = Iterator;
     
     cycle_iterator_adapter() = delete;
     
@@ -291,6 +291,7 @@ __host__ __device__ bool operator!=(const cycle_iterator_adapter<T>& lhs, const 
  */
 template <typename Key,
           typename Element,
+          typename size_type,
           Key unused_key,
           Element unused_element,
           typename Hasher = default_hash<Key>,
@@ -301,15 +302,14 @@ class concurrent_unordered_multimap : public managed
 {
 
 public:
-    typedef size_t                                          size_type;
-    typedef Hasher                                          hasher;
-    typedef Equality                                        key_equal;
-    typedef Allocator                                       allocator_type;
-    typedef Key                                             key_type;
-    typedef thrust::pair<Key, Element>                      value_type;
-    typedef Element                                         mapped_type;
-    typedef cycle_iterator_adapter<value_type*>             iterator;
-    typedef const cycle_iterator_adapter<value_type*>       const_iterator;
+    using hasher = Hasher;
+    using key_equal = Equality;
+    using allocator_type = Allocator;
+    using key_type = Key;
+    using value_type = thrust::pair<Key, Element>;
+    using mapped_type = Element;
+    using iterator = cycle_iterator_adapter<value_type*>;
+    using const_iterator = const cycle_iterator_adapter<value_type*>;
 
 private:
     union pair2longlong
@@ -377,7 +377,7 @@ public:
     {
         const size_type hashtbl_size    = m_hashtbl_size;
         value_type* hashtbl_values      = m_hashtbl_values;
-        const size_type key_hash        = m_hf( x.first );
+        const auto key_hash        = m_hf( x.first );
         size_type hash_tbl_idx          = key_hash%hashtbl_size;
         
         value_type* it = 0;
@@ -431,7 +431,7 @@ public:
     __forceinline__
     __host__ __device__ const_iterator find(const key_type& k ) const
     {
-        size_type key_hash = m_hf( k );
+        const auto key_hash = m_hf( k );
         size_type hash_tbl_idx = key_hash%m_hashtbl_size;
         
         value_type* begin_ptr = 0;

--- a/src/hashmap/hash_functions.cuh
+++ b/src/hashmap/hash_functions.cuh
@@ -51,7 +51,31 @@ struct MurmurHash3_32
         h ^= h >> 16;
         return h;
     }
+
     
+    /* --------------------------------------------------------------------------*/
+    /** 
+     * @Synopsis  Combines two hash values into a new single hash value. Called 
+     * repeatedly to create a hash value from several variables.
+     * Taken from the Boost hash_combine function 
+     * https://www.boost.org/doc/libs/1_35_0/doc/html/boost/hash_combine_id241013.html
+     * 
+     * @Param lhs The first hash value to combine
+     * @Param rhs The second hash value to combine
+     * 
+     * @Returns A hash value that intelligently combines the lhs and rhs hash values
+     */
+    /* ----------------------------------------------------------------------------*/
+    __host__ __device__ result_type hash_combine(result_type lhs, result_type rhs)
+    {
+      result_type combined{lhs};
+
+      combined ^= rhs + 0x9e3779b9 + (combined << 6) + (combined >> 2);
+
+      return combined;
+    }
+
+  
     __forceinline__ 
     __host__ __device__ result_type operator()(const Key& key) const
     {

--- a/src/join/hash/join_compute_api.h
+++ b/src/join/hash/join_compute_api.h
@@ -18,6 +18,7 @@
 #include <future>
 
 #include "join_kernels.cuh"
+#include "../../gdf_table.cuh"
 
 // TODO for Arrow integration:
 //   1) replace mgpu::context_t with a new CudaComputeContext class (see the design doc)
@@ -29,12 +30,16 @@
 
 #include <moderngpu/kernel_scan.hxx>
 
-constexpr int DEFAULT_HASH_TBL_OCCUPANCY = 50;
+constexpr int DEFAULT_HASH_TABLE_OCCUPANCY = 50;
 constexpr int DEFAULT_CUDA_BLOCK_SIZE = 128;
 constexpr int DEFAULT_CUDA_CACHE_SIZE = 128;
 
 template<typename size_type>
-struct join_pair { size_type first, second; };
+struct join_pair 
+{ 
+  size_type first; 
+  size_type second; 
+};
 
 /// \brief Transforms the data from an array of structurs to two column.
 ///
@@ -44,166 +49,181 @@ struct join_pair { size_type first, second; };
 ///
 /// \param[in] compute_ctx The CudaComputeContext to shedule this to.
 /// \param[in] Flag signifying if the order of the indices for A and B need to be swapped. This flag is used when the order of A and B are swapped to build the hash table for the smalle column.
-template<typename size_type, typename joined_type>
-void pairs_to_decoupled(mgpu::mem_t<size_type> &output, const size_type output_npairs, joined_type *joined, mgpu::context_t &context, bool flip_indices)
+template<typename size_type, typename join_output_pair>
+void pairs_to_decoupled(mgpu::mem_t<size_type> &output, const size_type output_npairs, join_output_pair *joined, mgpu::context_t &context, bool flip_indices)
 {
   if (output_npairs > 0) {
-	size_type* output_data = output.data();
-	auto k = [=] MGPU_DEVICE(size_type index) {
-	  output_data[index] = flip_indices ? joined[index].second : joined[index].first;
-	  output_data[index + output_npairs] = flip_indices ? joined[index].first : joined[index].second;
-	};
-	mgpu::transform(k, output_npairs, context);
+    size_type* output_data = output.data();
+    auto k = [=] MGPU_DEVICE(size_type index) {
+      output_data[index] = flip_indices ? joined[index].second : joined[index].first;
+      output_data[index + output_npairs] = flip_indices ? joined[index].first : joined[index].second;
+    };
+    mgpu::transform(k, output_npairs, context);
   }
 }
 
 
-/// \brief Performs a generic hash based join of columns a and b. Works for both inner and left joins.
-///
-/// \param[in] compute_ctx The CudaComputeContext to shedule this to.
-/// \param[out] out row references into a and b of matching rows
-/// \param[in] a first column to join (left)
-/// \param[in] Number of element in a column (left)
-/// \param[in] b second column to join (right)
-/// \param[in] Number of element in b column (right)
-/// \param[in] additional columns to join (default == NULL)
-/// \param[in] Flag used to reorder the left and right column indices found in the join (default = false)
-template<JoinType join_type,
-  typename input_it,
-  typename input2_it,
-  typename input3_it,
-  typename size_type>
-cudaError_t GenericJoinHash(mgpu::context_t &compute_ctx, mgpu::mem_t<size_type>& joined_output, 
-	const input_it a, const size_type a_count, const input_it b, const size_type b_count,
-	const input2_it a2 = (int*)NULL, const input2_it b2 = (int*)NULL,
-	const input3_it a3 = (int*)NULL, const input3_it b3 = (int*)NULL,
-	bool flip_results = false)
+/* --------------------------------------------------------------------------*/
+/** 
+* @Synopsis  Performs a hash-based join between two sets of gdf_tables.
+* 
+* @Param compute_ctx The Modern GPU context
+* @Param joined_output The output of the join operation
+* @Param left_table The left table to join
+* @Param right_table The right table to join
+* @Param flip_results Flag that indicates whether the left and right tables have been 
+* switched, indicating that the output indices should also be flipped
+* @tparam join_type The type of join to be performed
+* @tparam key_type The data type to be used for the Keys in the hash table
+* @tparam index_type The data type to be used for the output indices
+* 
+* @Returns  cudaSuccess upon successful completion of the join. Otherwise returns
+* the appropriate CUDA error code
+*/
+/* ----------------------------------------------------------------------------*/
+template<JoinType join_type, 
+         typename key_type, 
+         typename index_type,
+         typename size_type>
+cudaError_t compute_hash_join(mgpu::context_t & compute_ctx, 
+                              mgpu::mem_t<index_type> & joined_output, 
+                              gdf_table<size_type> const & left_table,
+                              gdf_table<size_type> const & right_table,
+                              bool flip_results = false)
 {
+
   cudaError_t error(cudaSuccess);
 
-  typedef typename std::iterator_traits<input_it>::value_type key_type;
-  typedef typename std::iterator_traits<input2_it>::value_type key_type2;
-  typedef typename std::iterator_traits<input3_it>::value_type key_type3;
-  typedef join_pair<size_type> joined_type;
-
-  // allocate a counter and reset
-  size_type *d_joined_idx;
-  CUDA_RT_CALL( cudaMalloc(&d_joined_idx, sizeof(size_type)) );
-  CUDA_RT_CALL( cudaMemsetAsync(d_joined_idx, 0, sizeof(size_type), 0) );
-
-  // step 0: check if the output is provided or we need to allocate it
-
-  // step 1: initialize a HT for table B (right)
+  // Data type used for join output results. Stored as a pair of indices 
+  // (left index, right index) where left_table[left index] == right_table[right index]
+  using join_output_pair = join_pair<index_type>;
+  
+  // The LEGACY allocator allocates the hash table array with normal cudaMalloc,
+  // the non-legacy allocator uses managed memory
 #ifdef HT_LEGACY_ALLOCATOR
-  typedef concurrent_unordered_multimap<key_type, size_type, std::numeric_limits<key_type>::max(), std::numeric_limits<size_type>::max(), default_hash<key_type>, equal_to<key_type>, legacy_allocator<thrust::pair<key_type, size_type> > > multimap_type;
+  using multimap_type = concurrent_unordered_multimap<key_type, 
+                                                      index_type, 
+                                                      size_type,
+                                                      std::numeric_limits<key_type>::max(), 
+                                                      std::numeric_limits<index_type>::max(), 
+                                                      default_hash<key_type>,
+                                                      equal_to<key_type>,
+                                                      legacy_allocator< thrust::pair<key_type, index_type> > >;
 #else
-  typedef concurrent_unordered_multimap<key_type, size_type, std::numeric_limits<key_type>::max(), std::numeric_limits<size_type>::max()> multimap_type;
+  using multimap_type = concurrent_unordered_multimap<key_type, 
+                                                      index_type, 
+                                                      size_type,
+                                                      std::numeric_limits<key_type>::max(), 
+                                                      std::numeric_limits<size_type>::max()>;
 #endif
-  size_type hash_tbl_size = (size_type)((size_t) b_count * 100 / DEFAULT_HASH_TBL_OCCUPANCY);
-  std::unique_ptr<multimap_type> hash_tbl(new multimap_type(hash_tbl_size));
-  hash_tbl->prefetch(0);  // FIXME: use GPU device id from the context? but moderngpu only provides cudaDeviceProp (although should be possible once we move to Arrow)
-  error = cudaGetLastError();
-  if (error != cudaSuccess)
-	return error;
 
-  // step 2: build the HT
+  // Hash table will be built on the right table
+  gdf_table<size_type> const & build_table{right_table};
+  const size_type build_column_length{build_table.get_column_length()};
+  const key_type * const build_column{static_cast<key_type*>(build_table.get_build_column_data())};
+
+  // Allocate the hash table
+  const size_type hash_table_size = (static_cast<size_type>(build_column_length) * 100 / DEFAULT_HASH_TABLE_OCCUPANCY);
+  std::unique_ptr<multimap_type> hash_table(new multimap_type(hash_table_size));
+  
+  // FIXME: use GPU device id from the context? 
+  // but moderngpu only provides cudaDeviceProp 
+  // (although should be possible once we move to Arrow)
+  hash_table->prefetch(0); 
+  
+  CUDA_RT_CALL( cudaDeviceSynchronize() );
+
+  // build the hash table
   constexpr int block_size = DEFAULT_CUDA_BLOCK_SIZE;
-  build_hash_tbl<<<(b_count + block_size-1) / block_size, block_size>>>(hash_tbl.get(), b, b_count);
-  error = cudaGetLastError();
-  if (error != cudaSuccess)
-	return error;
+  const size_type build_grid_size{(build_column_length + block_size - 1)/block_size};
+  build_hash_table<<<build_grid_size, block_size>>>(hash_table.get(), 
+                                                    build_column, 
+                                                    build_column_length);
+  
+  CUDA_RT_CALL( cudaGetLastError() );
 
+  // Allocate storage for the counter used to get the size of the join output
+  size_type * d_join_output_size;
+  cudaMalloc(&d_join_output_size, sizeof(size_type));
+  cudaMemset(d_join_output_size, 0, sizeof(size_type));
 
-  // step 3ab: scan table A (left), probe the HT without outputting the joined indices. Only get number of outputted elements.
-  size_type* d_actualFound;
-  cudaMalloc(&d_actualFound, sizeof(size_type));
-  cudaMemset(d_actualFound, 0, sizeof(size_type));
-  probe_hash_tbl_count_common<join_type, multimap_type, key_type, key_type2, key_type3, size_type, block_size, DEFAULT_CUDA_CACHE_SIZE>
-	<<<(a_count + block_size-1) / block_size, block_size>>>
-	(hash_tbl.get(), a, a_count, a2, b2, a3, b3,d_actualFound);
-  if (error != cudaSuccess)
-	return error;
+  // Probe with the left table
+  gdf_table<size_type> const & probe_table{left_table};
+  const size_type probe_column_length{probe_table.get_column_length()};
+  const key_type * const probe_column{static_cast<key_type*>(probe_table.get_probe_column_data())};
+  const size_type probe_grid_size{(probe_column_length + block_size -1)/block_size};
 
-  size_type scanSize=0;
-  CUDA_RT_CALL( cudaMemcpy(&scanSize, d_actualFound, sizeof(size_type), cudaMemcpyDeviceToHost));
+  // Probe the hash table without actually building the output to simply
+  // find what the size of the output will be.
+  compute_join_output_size<join_type, 
+                           multimap_type, 
+                           key_type, 
+                           size_type,
+                           block_size, 
+                           DEFAULT_CUDA_CACHE_SIZE>
+	<<<probe_grid_size, block_size>>>(hash_table.get(), 
+                                    build_table, 
+                                    probe_table, 
+                                    probe_column,
+                                    probe_table.get_column_length(),
+                                    d_join_output_size);
 
-  int dev_ordinal;
-  joined_type* tempOut=NULL;
-  CUDA_RT_CALL( cudaGetDevice(&dev_ordinal));
-  joined_output = mgpu::mem_t<size_type> (2 * (scanSize), compute_ctx);
+  CUDA_RT_CALL( cudaGetLastError() );
 
-  // Checking if any common elements exists. If not, then there is no point scanning again.
-  if(scanSize==0){
-	return error;
+  // Copy output size from the device to host
+  size_type h_join_output_size{0};
+  CUDA_RT_CALL( cudaMemcpy(&h_join_output_size, d_join_output_size, sizeof(size_type), cudaMemcpyDeviceToHost));
+  
+  // If the output size is zero, return immediately
+  if(0 == h_join_output_size){
+    return error;
   }
 
-  CUDA_RT_CALL( cudaMallocManaged   ( &tempOut, sizeof(joined_type)*scanSize));
-  CUDA_RT_CALL( cudaMemPrefetchAsync( tempOut , sizeof(joined_type)*scanSize, dev_ordinal));
+  // Allocate modern GPU storage for the join output
+  int dev_ordinal{0};
+  join_output_pair* tempOut{nullptr};
+  CUDA_RT_CALL( cudaGetDevice(&dev_ordinal));
+  joined_output = mgpu::mem_t<size_type> (2 * (h_join_output_size), compute_ctx);
 
-  CUDA_RT_CALL( cudaMemset(d_joined_idx, 0, sizeof(size_type)) );
-  // step 3b: scan table A (left), probe the HT and output the joined indices - doing left join here
-  probe_hash_tbl<join_type, multimap_type, key_type, key_type2, key_type3, size_type, joined_type, block_size, DEFAULT_CUDA_CACHE_SIZE>
-	<<<(a_count + block_size-1) / block_size, block_size>>>
-	(hash_tbl.get(), a, a_count, a2, b2, a3, b3,
-	 static_cast<joined_type*>(tempOut), d_joined_idx, scanSize);
-  error = cudaDeviceSynchronize();
+  // Allocate temporary device buffer for join output
+  CUDA_RT_CALL( cudaMallocManaged   ( &tempOut, sizeof(join_output_pair)*h_join_output_size));
+  CUDA_RT_CALL( cudaMemPrefetchAsync( tempOut , sizeof(join_output_pair)*h_join_output_size, dev_ordinal));
+
+  // Allocate device global counter used by threads to determine output write location
+  size_type *d_global_write_index{nullptr};
+  CUDA_RT_CALL( cudaMalloc(&d_global_write_index, sizeof(size_type)) );
+  CUDA_RT_CALL( cudaMemsetAsync(d_global_write_index, 0, sizeof(size_type), 0) );
+
+  // Do the probe of the hash table with the probe table and generate the output for the join
+  probe_hash_table<join_type, 
+                   multimap_type, 
+                   key_type, 
+                   size_type, 
+                   join_output_pair, 
+                   block_size, 
+                   DEFAULT_CUDA_CACHE_SIZE>
+	<<<probe_grid_size, block_size>>> (hash_table.get(), 
+                                     build_table, 
+                                     probe_table, 
+                                     probe_column, 
+                                     probe_table.get_column_length(), 
+                                     static_cast<join_output_pair*>(tempOut), 
+                                     d_global_write_index, 
+                                     h_join_output_size);
+
+  CUDA_RT_CALL(cudaDeviceSynchronize());
 
   // free memory used for the counters
-  CUDA_RT_CALL( cudaFree(d_joined_idx) );
-  CUDA_RT_CALL( cudaFree(d_actualFound) ); 
+  CUDA_RT_CALL( cudaFree(d_global_write_index) );
+  CUDA_RT_CALL( cudaFree(d_join_output_size) ); 
 
+  // Transform the join output from an array of pairs, to an array of indices where the first
+  // n/2 elements are the left indices and the last n/2 elements are the right indices
+  pairs_to_decoupled(joined_output, h_join_output_size, tempOut, compute_ctx, flip_results);
 
-  pairs_to_decoupled(joined_output, scanSize, tempOut, compute_ctx, flip_results);
-
+  // Free temporary device buffer
   CUDA_RT_CALL( cudaFree(tempOut) );
+
   return error;
 }
 
-
-/// \brief Performs a hash based left join of columns a and b.
-///
-/// \param[in] compute_ctx The CudaComputeContext to shedule this to.
-/// \param[out] out row references into a and b of matching rows
-/// \param[in] a first column to join (left)
-/// \param[in] Number of element in a column (left)
-/// \param[in] b second column to join (right)
-/// \param[in] Number of element in b column (right)
-/// \param[in] additional columns to join (default == NULL)
-template<typename input_it,
-  typename input2_it,
-  typename input3_it,
-  typename size_type>
-  cudaError_t LeftJoinHash(mgpu::context_t &compute_ctx, mgpu::mem_t<size_type>& joined_output, 
-	  const input_it a, const size_type a_count, const input_it b, const size_type b_count,
-	  const input2_it a2 = (int*)NULL, const input2_it b2 = (int*)NULL,
-	  const input3_it a3 = (int*)NULL, const input3_it b3 = (int*)NULL){
-
-
-	return GenericJoinHash<JoinType::LEFT_JOIN>(compute_ctx, joined_output, a, a_count, b, b_count, a2, b2, a3, b3);
-  }
-
-
-/// \brief Performs a hash based inner join of columns a and b.
-///
-/// \param[in] compute_ctx The CudaComputeContext to shedule this to.
-/// \param[out] out row references into a and b of matching rows
-/// \param[in] a first column to join (left)
-/// \param[in] Number of element in a column (left)
-/// \param[in] b second column to join (right)
-/// \param[in] Number of element in b column (right)
-/// \param[in] additional columns to join (default == NULL)
-/// \param[in] Flag used to reorder the left and right column indices found in the join (default = false)
-template<typename input_it,
-  typename input2_it,
-  typename input3_it,
-  typename size_type>
-  cudaError_t InnerJoinHash(mgpu::context_t &compute_ctx, mgpu::mem_t<size_type>& joined_output, 
-	  const input_it a, const size_type a_count, const input_it b, const size_type b_count,
-	  const input2_it a2 = (int*)NULL, const input2_it b2 = (int*)NULL,
-	  const input3_it a3 = (int*)NULL, const input3_it b3 = (int*)NULL){
-
-	if (b_count > a_count)
-	  return GenericJoinHash<JoinType::INNER_JOIN>(compute_ctx, joined_output, b, b_count, a, a_count, b2, a2, b3, a3, true);
-	else
-	  return GenericJoinHash<JoinType::INNER_JOIN>(compute_ctx, joined_output, a, a_count, b, b_count, a2, b2, a3, b3);
-  }

--- a/src/join/hash/join_kernels.cuh
+++ b/src/join/hash/join_kernels.cuh
@@ -21,31 +21,61 @@ enum class JoinType {
   LEFT_JOIN,
 };
 
+#include "../../gdf_table.cuh"
 #include "../../hashmap/concurrent_unordered_multimap.cuh"
 #include <cub/cub.cuh>
 
 constexpr int warp_size = 32;
 
-template<typename multimap_type>
-__global__ void build_hash_tbl(
-    multimap_type * const multi_map,
-    const typename multimap_type::key_type* const build_tbl,
-    const typename multimap_type::size_type build_tbl_size)
+/* --------------------------------------------------------------------------*/
+/** 
+* @Synopsis  Builds a hash table from a gdf_table that maps the values of the build
+* column to its respective row indices.
+* 
+* @Param multi_map The hash table to be built
+* @Param build_column The column from the build table to build the hash table on
+* @Param build_column_size The size of the build column
+* @tparam multimap_type The type of the hash table
+* @tparam key_type The datatype used for the Keys in the hash table
+* 
+*/
+/* ----------------------------------------------------------------------------*/
+template<typename multimap_type,
+         typename key_type = typename multimap_type::key_type,
+         typename size_type = typename multimap_type::size_type>
+__global__ void build_hash_table( multimap_type * const multi_map,
+                                  const key_type * const build_column,
+                                  const size_type build_column_size)
 {
+    const size_type i = threadIdx.x + blockIdx.x * blockDim.x;
 
-    using mapped_type = typename multimap_type::mapped_type;
-    
-    const typename multimap_type::size_type i = threadIdx.x + blockIdx.x * blockDim.x;
-    if ( i < build_tbl_size ) {
-      multi_map->insert( thrust::make_pair( build_tbl[i], (mapped_type) i ) );
+    if ( i < build_column_size ) {
+      multi_map->insert( thrust::make_pair( build_column[i], i ) );
     }
 }
 
+/* --------------------------------------------------------------------------*/
+/** 
+* @Synopsis  Adds a pair of indices to the shared memory cache
+* 
+* @Param first The first index in the pair
+* @Param second The second index in the pair
+* @Param current_idx_shared Pointer to shared index that determines where in the shared
+memory cache the pair will be written
+* @Param warp_id The ID of the warp of the calling the thread
+* @Param joined_shared Pointer to the shared memory cache
+* 
+*/
+/* ----------------------------------------------------------------------------*/
 template<typename size_type,
-	 typename joined_type>
-__inline__ __device__ void add_pair_to_cache(const size_type first, const size_type second, int *current_idx_shared, const int warp_id, joined_type *joined_shared)
+         typename join_output_pair>
+__inline__ __device__ void add_pair_to_cache(const size_type first, 
+                                             const size_type second, 
+                                             int *current_idx_shared, 
+                                             const int warp_id, 
+                                             join_output_pair *joined_shared)
 {
-  joined_type joined_val;
+  join_output_pair joined_val;
   joined_val.first = first;
   joined_val.second = second;
 
@@ -55,244 +85,308 @@ __inline__ __device__ void add_pair_to_cache(const size_type first, const size_t
   joined_shared[my_current_idx] = joined_val;
 }
 
-template<
-JoinType join_type,
-		 typename multimap_type,
-		 typename key_type,
-		 typename key2_type,
-		 typename key3_type,
-		 typename size_type,
-		 int block_size,
-  int output_cache_size>
-__global__ void probe_hash_tbl_count_common(
-	multimap_type * multi_map,
-	const key_type* probe_tbl,
-	const size_type probe_tbl_size,
-	const key2_type* probe_col2, const key2_type* build_col2,
-	const key3_type* probe_col3, const key3_type* build_col3,
-    size_type* globalCounterFound
-    )
+/* --------------------------------------------------------------------------*/
+/** 
+* @Synopsis  Computes the output size of joining the probe table to the build table.
+* 
+* @Param[in] multi_map The hash table built on the build table
+* @Param[in] build_table The build table
+* @Param[in] probe_table The probe table
+* @Param[in] probe_column The column to be used to probe the hash table for potential matches
+* @Param[in] probe_table_size The length of the probe table's columns
+* @Param[out] output_size The resulting output size
+  @tparam join_type The type of join to be performed
+  @tparam multimap_type The datatype of the hash table
+  @tparam key_type The datatype of the Keys in the hash table
+  @tparam block_size The number of threads in a thread block for the kernel
+  @tparam output_cache_size The size of the shared memory cache for caching the join output results
+* 
+*/
+/* ----------------------------------------------------------------------------*/
+template< JoinType join_type,
+          typename multimap_type,
+          typename key_type,
+          typename size_type,
+          int block_size,
+          int output_cache_size>
+__global__ void compute_join_output_size( multimap_type const * const multi_map,
+                                          gdf_table<size_type> const & build_table,
+                                          gdf_table<size_type> const & probe_table,
+                                          key_type const * const probe_column,
+                                          const size_type probe_table_size,
+                                          size_type* output_size)
 {
- 
-    typedef typename multimap_type::key_equal key_compare_type;
 
-    __shared__ int countFound;
-    countFound=0;
-    __syncthreads();
-
-    key_compare_type key_compare;
+  __shared__ size_type block_counter;
+  block_counter=0;
+  __syncthreads();
 
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 9000
-    __syncwarp();
+  __syncwarp();
 #endif
 
-    size_type i = threadIdx.x + blockIdx.x * blockDim.x;
+  size_type probe_row_index = threadIdx.x + blockIdx.x * blockDim.x;
 
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 9000
-    const unsigned int activemask = __ballot_sync(0xffffffff, i < probe_tbl_size);
+  const unsigned int activemask = __ballot_sync(0xffffffff, probe_row_index < probe_table_size);
 #endif
-    if ( i < probe_tbl_size ) {
-    	const auto unused_key = multi_map->get_unused_key();
-    	const auto end = multi_map->end();
-    	const key_type probe_key = probe_tbl[i];
-    	auto it = multi_map->find(probe_key);
+  if ( probe_row_index < probe_table_size ) {
+    const auto unused_key = multi_map->get_unused_key();
+    const auto end = multi_map->end();
+    const key_type probe_key = probe_column[probe_row_index];
+    auto found = multi_map->find(probe_key);
 
-    	bool running = (join_type == JoinType::LEFT_JOIN) || (end != it); // for left-joins we always need to add an output
-    	bool found_match = false;
+    bool running = (join_type == JoinType::LEFT_JOIN) || (end != found); // for left-joins we always need to add an output
+    bool found_match = false;
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 9000
-        while ( __any_sync( activemask, running ) )
+    while ( __any_sync( activemask, running ) )
 #else
-        while ( __any( running ) )
+      while ( __any( running ) )
 #endif
+      {
+        if ( running )
         {
-    		if ( running )
-    		{
-                if (join_type == JoinType::LEFT_JOIN && (end == it)) {
-                    running = false;    // add once on the first iteration
-                }
-                else if ( key_compare( unused_key, it->first ) ) {
-                    running = false;
-                }
-                else if (!key_compare( probe_key, it->first ) ||
-                    ((probe_col2 != NULL) && (probe_col2[i] != build_col2[it->second])) ||
-                    ((probe_col3 != NULL) && (probe_col3[i] != build_col3[it->second]))) {
-                    ++it;
-                    running = (end != it);
-                }
-                else {
-					atomicAdd(&countFound,1) ;
-                    ++it;
-                    running = (end != it);
-                    found_match = true;
-                }
+          if (join_type == JoinType::LEFT_JOIN && (end == found)) {
+            running = false;    // add once on the first iteration
+          }
+          else if ( unused_key == found->first ) {
+            running = false;
+          }
+          else if (false == probe_table.rows_equal(build_table, probe_row_index, found->second))
+          {
 
-                if ((join_type == JoinType::LEFT_JOIN) && (!running) && (!found_match)) {
-                    atomicAdd(&countFound,1);
-                }
-		  }
-	   }
-    }
-    __syncthreads();
-    if (threadIdx.x==0)
-        atomicAdd(globalCounterFound,countFound);
+            // Continue searching for matching rows until you hit an empty hash table entry
+            ++found;
+            if(end == found)
+              found = multi_map->begin();
 
+            if(unused_key == found->first)
+              running = false;
+          }
+          else 
+          {
+            found_match = true;
 
+            atomicAdd(&block_counter,static_cast<size_type>(1)) ;
+
+            // Continue searching for matching rows until you hit an empty hash table entry
+            ++found;
+            if(end == found)
+              found = multi_map->begin();
+
+            if(unused_key == found->first)
+              running = false;
+          }
+
+          if ((join_type == JoinType::LEFT_JOIN) && (!running) && (!found_match)) {
+            atomicAdd(&block_counter,static_cast<size_type>(1));
+          }
+        }
+      }
+  }
+
+  __syncthreads();
+
+  // Add block counter to global counter
+  if (threadIdx.x==0)
+    atomicAdd(output_size, block_counter);
 }
 
 
-
-template<
-    JoinType join_type,
-    typename multimap_type,
-    typename key_type,
-    typename key2_type,
-    typename key3_type,
-    typename size_type,
-    typename joined_type,
-    int block_size,
-    int output_cache_size>
-__global__ void probe_hash_tbl(
-    multimap_type * multi_map,
-    const key_type* probe_tbl,
-    const size_type probe_tbl_size,
-    const key2_type* probe_col2, const key2_type* build_col2,
-    const key3_type* probe_col3, const key3_type* build_col3,
-    joined_type * const joined,
-    size_type* const current_idx,
-    const size_type max_size,
-    const size_type offset = 0,
-    const bool optimized = false)
+/* --------------------------------------------------------------------------*/
+/** 
+ * @Synopsis  Uses the hash table built from the build table to compute the 
+ result of the join operation.
+ * 
+ * @Param multi_map The hash table built from the build table
+ * @Param build_table The build table
+ * @Param probe_table The probe table
+ * @Param probe_column The column from the probe table that is used to probe the hash table
+ * @Param probe_table_size The length of the columns in the probe table
+ * @Param join_output The result of the join operation
+ * @Param current_idx A global counter used by threads to coordinate writes to the global output
+ * @Param max_size The maximum size of the output
+ * @Param offset An optional offset
+ * @tparam join_type The type of join to be performed
+ * @tparam multimap_type The type of the hash table
+ * @tparam key_type The data type of the Keys in the hash table
+ * @tparam join_output_pair The pair datatype used for the join result
+ * @tparam block_size The number of threads per block for this kernel
+ * @tparam output_cache_size The side of the shared memory buffer to cache join output results
+ * 
+ */
+/* ----------------------------------------------------------------------------*/
+template< JoinType join_type,
+          typename multimap_type,
+          typename key_type,
+          typename size_type,
+          typename join_output_pair,
+          size_type block_size,
+          size_type output_cache_size>
+__global__ void probe_hash_table( multimap_type const * const multi_map,
+                                  gdf_table<size_type> const & build_table,
+                                  gdf_table<size_type> const & probe_table,
+                                  key_type const * const probe_column,
+                                  const size_type probe_table_size,
+                                  join_output_pair * const join_output,
+                                  size_type* current_idx,
+                                  const size_type max_size,
+                                  const size_type offset = 0)
 {
-    typedef typename multimap_type::key_equal key_compare_type;
-    __shared__ int current_idx_shared[block_size/warp_size];
-    __shared__ joined_type joined_shared[block_size/warp_size][output_cache_size];
+  constexpr int num_warps = block_size/warp_size;
+  __shared__ int current_idx_shared[num_warps];
+  __shared__ join_output_pair join_output_shared[num_warps][output_cache_size];
 
-    const int warp_id = threadIdx.x/warp_size;
-    const int lane_id = threadIdx.x%warp_size;
+  const int warp_id = threadIdx.x/warp_size;
+  const int lane_id = threadIdx.x%warp_size;
 
-    key_compare_type key_compare;
-
-    if ( 0 == lane_id )
-        current_idx_shared[warp_id] = 0;
+  if ( 0 == lane_id )
+  {
+    current_idx_shared[warp_id] = 0;
+  }
 
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 9000
-    __syncwarp();
+  __syncwarp();
 #endif
 
-    size_type i = threadIdx.x + blockIdx.x * blockDim.x;
+  size_type probe_row_index = threadIdx.x + blockIdx.x * blockDim.x;
+
 
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 9000
-    const unsigned int activemask = __ballot_sync(0xffffffff, i < probe_tbl_size);
+  const unsigned int activemask = __ballot_sync(0xffffffff, probe_row_index < probe_table_size);
 #endif
-    if ( i < probe_tbl_size ) {
-        const auto unused_key = multi_map->get_unused_key();
-        const auto end = multi_map->end();
-        const key_type probe_key = probe_tbl[i];
-        auto it = multi_map->find(probe_key);
+  if ( probe_row_index < probe_table_size ) {
+    const auto unused_key = multi_map->get_unused_key();
+    const auto end = multi_map->end();
+    const key_type probe_key = probe_column[probe_row_index];
+    auto found = multi_map->find(probe_key);
 
-        bool running = (join_type == JoinType::LEFT_JOIN) || (end != it);	// for left-joins we always need to add an output
-	bool found_match = false;
+    bool running = (join_type == JoinType::LEFT_JOIN) || (end != found);	// for left-joins we always need to add an output
+    bool found_match = false;
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 9000
-        while ( __any_sync( activemask, running ) )
+    while ( __any_sync( activemask, running ) )
 #else
-        while ( __any( running ) )
+      while ( __any( running ) )
 #endif
+      {
+        if ( running )
         {
-            if ( running )
-            {
-		if (join_type == JoinType::LEFT_JOIN && (end == it)) {
-		    running = false;	// add once on the first iteration
-		}
-		else if ( key_compare( unused_key, it->first ) ) {
-                    running = false;
-                }
-                else if (!key_compare( probe_key, it->first ) ||
-			 ((probe_col2 != NULL) && (probe_col2[i] != build_col2[it->second])) ||
-			 ((probe_col3 != NULL) && (probe_col3[i] != build_col3[it->second]))) {
-                    ++it;
-                    running = (end != it);
-                }
-                else {
-		    add_pair_to_cache(offset+i, it->second, current_idx_shared, warp_id, joined_shared[warp_id]);
+          if (join_type == JoinType::LEFT_JOIN && (end == found)) {
+            // add once on the first iteration
+            running = false;	
+          }
+          else if ( unused_key == found->first ) {
+            running = false;
+          }
+          else if ( false == probe_table.rows_equal(build_table, probe_row_index, found->second) ){
 
-                    ++it;
-                    running = (end != it);
-		    found_match = true;
-                }
-		if ((join_type == JoinType::LEFT_JOIN) && (!running) && (!found_match)) {
-		  add_pair_to_cache(offset+i, JoinNoneValue, current_idx_shared, warp_id, joined_shared[warp_id]);
-		}
-            }
+            // Keep searching for matches until you encounter an empty hash table location 
+            ++found;
+            if(end == found)
+              found = multi_map->begin();
 
-#if defined(CUDA_VERSION) && CUDA_VERSION >= 9000
-            __syncwarp(activemask);
-#endif
-            //flush output cache if next iteration does not fit
-            if ( current_idx_shared[warp_id]+warp_size >= output_cache_size ) {
-                // count how many active threads participating here which could be less than warp_size
-#if defined(CUDA_VERSION) && CUDA_VERSION < 9000
-                const unsigned int activemask = __ballot(1);
-#endif
-                int num_threads = __popc(activemask);
-                unsigned long long int output_offset = 0;
-                if ( 0 == lane_id )
-                    output_offset = atomicAdd( current_idx, current_idx_shared[warp_id] );
-                output_offset = cub::ShuffleIndex(output_offset, 0, warp_size, activemask);
+            if(unused_key == found->first)
+              running = false;
+          }
+          else {
+            found_match = true;
 
-                for ( int shared_out_idx = lane_id; shared_out_idx<current_idx_shared[warp_id]; shared_out_idx+=num_threads ) {
-                    size_type thread_offset = output_offset + shared_out_idx;
-                    if (thread_offset < max_size)
-		       joined[thread_offset] = joined_shared[warp_id][shared_out_idx];
-                }
-#if defined(CUDA_VERSION) && CUDA_VERSION >= 9000
-                __syncwarp(activemask);
-#endif
-                if ( 0 == lane_id )
-                    current_idx_shared[warp_id] = 0;
-#if defined(CUDA_VERSION) && CUDA_VERSION >= 9000
-                __syncwarp(activemask);
-#endif
-            }
+            add_pair_to_cache(offset + probe_row_index, found->second, current_idx_shared, warp_id, join_output_shared[warp_id]);
+
+            // Keep searching for matches until you encounter an empty hash table location 
+            ++found;
+            if(end == found)
+              found = multi_map->begin();
+
+            if(unused_key == found->first)
+              running = false;
+          }
+          if ((join_type == JoinType::LEFT_JOIN) && (!running) && (!found_match)) {
+            add_pair_to_cache(offset + probe_row_index, JoinNoneValue, current_idx_shared, warp_id, join_output_shared[warp_id]);
+          }
         }
 
-        //final flush of output cache
-        if ( current_idx_shared[warp_id] > 0 ) {
-            // count how many active threads participating here which could be less than warp_size
-#if defined(CUDA_VERSION) && CUDA_VERSION < 9000
-            const unsigned int activemask = __ballot(1);
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 9000
+        __syncwarp(activemask);
 #endif
-            int num_threads = __popc(activemask);
-            unsigned long long int output_offset = 0;
-            if ( 0 == lane_id )
-                output_offset = atomicAdd( current_idx, current_idx_shared[warp_id] );
-            output_offset = cub::ShuffleIndex(output_offset, 0, warp_size, activemask);
+        //flush output cache if next iteration does not fit
+        if ( current_idx_shared[warp_id] + warp_size >= output_cache_size ) {
 
-            for ( int shared_out_idx = lane_id; shared_out_idx<current_idx_shared[warp_id]; shared_out_idx+=num_threads ) {
-                size_type thread_offset = output_offset + shared_out_idx;
-		if (thread_offset < max_size)
-                   joined[thread_offset] = joined_shared[warp_id][shared_out_idx];
-            }
+          // count how many active threads participating here which could be less than warp_size
+#if defined(CUDA_VERSION) && CUDA_VERSION < 9000
+          const unsigned int activemask = __ballot(1);
+#endif
+          int num_threads = __popc(activemask);
+          unsigned long long int output_offset = 0;
+
+          if ( 0 == lane_id )
+          {
+            output_offset = atomicAdd( current_idx, current_idx_shared[warp_id] );
+          }
+
+          output_offset = cub::ShuffleIndex(output_offset, 0, warp_size, activemask);
+
+          for ( int shared_out_idx = lane_id; shared_out_idx<current_idx_shared[warp_id]; shared_out_idx+=num_threads ) 
+          {
+            size_type thread_offset = output_offset + shared_out_idx;
+            if (thread_offset < max_size)
+              join_output[thread_offset] = join_output_shared[warp_id][shared_out_idx];
+          }
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 9000
+          __syncwarp(activemask);
+#endif
+          if ( 0 == lane_id )
+            current_idx_shared[warp_id] = 0;
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 9000
+          __syncwarp(activemask);
+#endif
         }
+      }
+
+    //final flush of output cache
+    if ( current_idx_shared[warp_id] > 0 ) 
+    {
+      // count how many active threads participating here which could be less than warp_size
+#if defined(CUDA_VERSION) && CUDA_VERSION < 9000
+      const unsigned int activemask = __ballot(1);
+#endif
+      int num_threads = __popc(activemask);
+      unsigned long long int output_offset = 0;
+      if ( 0 == lane_id )
+      {
+        output_offset = atomicAdd( current_idx, current_idx_shared[warp_id] );
+      }
+        
+      output_offset = cub::ShuffleIndex(output_offset, 0, warp_size, activemask);
+
+      for ( int shared_out_idx = lane_id; shared_out_idx<current_idx_shared[warp_id]; shared_out_idx+=num_threads ) {
+        size_type thread_offset = output_offset + shared_out_idx;
+        if (thread_offset < max_size)
+          join_output[thread_offset] = join_output_shared[warp_id][shared_out_idx];
+      }
     }
+  }
 }
 
+/*
+   // TODO This kernel still needs to be updated to work with an arbitrary number of columns
 template<
     typename multimap_type,
     typename key_type,
     typename size_type,
-    typename joined_type,
+    typename join_output_pair,
     int block_size>
-__global__ void probe_hash_tbl_uniq_keys(
+__global__ void probe_hash_table_uniq_keys(
     multimap_type * multi_map,
-    const key_type* probe_tbl,
-    const size_type probe_tbl_size,
-    joined_type * const joined,
+    const key_type* probe_table,
+    const size_type probe_table_size,
+    join_output_pair * const joined,
     size_type* const current_idx,
     const size_type offset)
 {
     __shared__ int current_idx_shared;
     __shared__ size_type output_offset_shared;
-    __shared__ joined_type joined_shared[block_size];
+    __shared__ join_output_pair joined_shared[block_size];
     if ( 0 == threadIdx.x ) {
         output_offset_shared = 0;
         current_idx_shared = 0;
@@ -301,13 +395,13 @@ __global__ void probe_hash_tbl_uniq_keys(
     __syncthreads();
 
     size_type i = threadIdx.x + blockIdx.x * blockDim.x;
-    if ( i < probe_tbl_size ) {
+    if ( i < probe_table_size ) {
         const auto end = multi_map->end();
-        auto it = multi_map->find(probe_tbl[i]);
-        if ( end != it ) {
-            joined_type joined_val;
+        auto found = multi_map->find(probe_table[i]);
+        if ( end != found ) {
+            join_output_pair joined_val;
             joined_val.first = offset+i;
-            joined_val.second = it->second;
+            joined_val.second = found->second;
             int my_current_idx = atomicAdd( &current_idx_shared, 1 );
             //its guranteed to fit into the shared cache
             joined_shared[my_current_idx] = joined_val;
@@ -328,3 +422,4 @@ __global__ void probe_hash_tbl_uniq_keys(
     }
 }
 
+*/

--- a/src/join/joining.cu
+++ b/src/join/joining.cu
@@ -16,8 +16,10 @@
 
 #include <gdf/gdf.h>
 #include <gdf/errorutils.h>
+#include <limits>
 
 #include "joining.h"
+#include "../gdf_table.cuh"
 
 using namespace mgpu;
 
@@ -57,8 +59,10 @@ size_t gdf_join_result_size(gdf_join_result_type *result) {
 
 // Size limit due to use of int32 as join output.
 // FIXME: upgrade to 64-bit
-#define MAX_JOIN_SIZE (0xffffffffu)
+using output_type = int;
+constexpr output_type MAX_JOIN_SIZE{std::numeric_limits<output_type>::max()};
 
+// TODO This macro stuff will go away once Outer join is implemented
 #define DEF_JOIN(Fn, T, Joiner)                                             \
 gdf_error gdf_##Fn(gdf_column *leftcol, gdf_column *rightcol,               \
                    gdf_join_result_type **out_result) {                     \
@@ -75,18 +79,21 @@ gdf_error gdf_##Fn(gdf_column *leftcol, gdf_column *rightcol,               \
     return GDF_SUCCESS;                                                     \
 }
 
-#define DEF_JOIN_GENERIC(Fn)                                               \
-gdf_error gdf_##Fn##_generic(gdf_column *leftcol, gdf_column * rightcol,   \
-                                 gdf_join_result_type **out_result) {      \
-    switch ( leftcol->dtype ){                                             \
-    case GDF_INT8:    return gdf_##Fn##_i8 (leftcol, rightcol, out_result);\
-    case GDF_INT16:   return gdf_##Fn##_i16(leftcol, rightcol, out_result);\
-    case GDF_INT32:   return gdf_##Fn##_i32(leftcol, rightcol, out_result);\
-    case GDF_INT64:   return gdf_##Fn##_i64(leftcol, rightcol, out_result);\
-    case GDF_FLOAT32: return gdf_##Fn##_f32(leftcol, rightcol, out_result);\
-    case GDF_FLOAT64: return gdf_##Fn##_f64(leftcol, rightcol, out_result);\
-    default: return GDF_UNSUPPORTED_DTYPE;                                 \
-    }                                                                      \
+#define DEF_JOIN_GENERIC(Fn)                                                 \
+gdf_error gdf_##Fn##_generic(gdf_column *leftcol, gdf_column * rightcol,     \
+                                 gdf_join_result_type **out_result) {        \
+    switch ( leftcol->dtype ){                                               \
+    case GDF_INT8:      return gdf_##Fn##_i8 (leftcol, rightcol, out_result);\
+    case GDF_INT16:     return gdf_##Fn##_i16(leftcol, rightcol, out_result);\
+    case GDF_INT32:     return gdf_##Fn##_i32(leftcol, rightcol, out_result);\
+    case GDF_INT64:     return gdf_##Fn##_i64(leftcol, rightcol, out_result);\
+    case GDF_FLOAT32:   return gdf_##Fn##_f32(leftcol, rightcol, out_result);\
+    case GDF_FLOAT64:   return gdf_##Fn##_f64(leftcol, rightcol, out_result);\
+    case GDF_DATE32:    return gdf_##Fn##_i32(leftcol, rightcol, out_result);\
+    case GDF_DATE64:    return gdf_##Fn##_i64(leftcol, rightcol, out_result);\
+    case GDF_TIMESTAMP: return gdf_##Fn##_i64(leftcol, rightcol, out_result);\
+    default: return GDF_UNSUPPORTED_DTYPE;                                   \
+    }                                                                        \
 }
 
 #define DEF_OUTER_JOIN(Fn, T) DEF_JOIN(outer_join_ ## Fn, T, outer_join)
@@ -98,82 +105,31 @@ DEF_OUTER_JOIN(i64, int64_t)
 DEF_OUTER_JOIN(f32, int32_t)
 DEF_OUTER_JOIN(f64, int64_t)
 
-#define JOIN_HASH_TYPES(T1, l1, r1, T2, l2, r2, T3, l3, r3) \
-  result_ptr->result = join_hash<join_type>( \
-				(T1*)l1, (int)leftcol[0]->size, \
-                                (T1*)r1, (int)rightcol[0]->size, \
-                                (T2*)l2, (T2*)r2, \
-                                (T3*)l3, (T3*)r3, \
-                                less_t<int64_t>(), result_ptr->context);
-
-#define JOIN_HASH_T3(T1, l1, r1, T2, l2, r2, T3, l3, r3) \
-  if (T3 == GDF_INT8)      { JOIN_HASH_TYPES(T1, l1, r1, T2, l2, r2,  int8_t, l3, r3) } \
-  if (T3 == GDF_INT16)     { JOIN_HASH_TYPES(T1, l1, r1, T2, l2, r2, int16_t, l3, r3) } \
-  if (T3 == GDF_INT32)     { JOIN_HASH_TYPES(T1, l1, r1, T2, l2, r2, int32_t, l3, r3) } \
-  if (T3 == GDF_INT64)     { JOIN_HASH_TYPES(T1, l1, r1, T2, l2, r2, int64_t, l3, r3) } \
-  if (T3 == GDF_FLOAT32)   { JOIN_HASH_TYPES(T1, l1, r1, T2, l2, r2, int32_t, l3, r3) } \
-  if (T3 == GDF_FLOAT64)   { JOIN_HASH_TYPES(T1, l1, r1, T2, l2, r2, int64_t, l3, r3) } \
-  if (T3 == GDF_DATE32)    { JOIN_HASH_TYPES(T1, l1, r1, T2, l2, r2, int32_t, l3, r3) } \
-  if (T3 == GDF_DATE64)    { JOIN_HASH_TYPES(T1, l1, r1, T2, l2, r2, int64_t, l3, r3) } \
-  if (T3 == GDF_TIMESTAMP) { JOIN_HASH_TYPES(T1, l1, r1, T2, l2, r2, int64_t, l3, r3) }
-
-#define JOIN_HASH_T2(T1, l1, r1, T2, l2, r2, T3, l3, r3) \
-  if (T2 == GDF_INT8)       { JOIN_HASH_T3(T1, l1, r1,  int8_t, l2, r2, T3, l3, r3) } \
-  if (T2 == GDF_INT16)      { JOIN_HASH_T3(T1, l1, r1, int16_t, l2, r2, T3, l3, r3) } \
-  if (T2 == GDF_INT32)      { JOIN_HASH_T3(T1, l1, r1, int32_t, l2, r2, T3, l3, r3) } \
-  if (T2 == GDF_INT64)      { JOIN_HASH_T3(T1, l1, r1, int64_t, l2, r2, T3, l3, r3) } \
-  if (T2 == GDF_FLOAT32)    { JOIN_HASH_T3(T1, l1, r1, int32_t, l2, r2, T3, l3, r3) } \
-  if (T2 == GDF_FLOAT64)    { JOIN_HASH_T3(T1, l1, r1, int64_t, l2, r2, T3, l3, r3) } \
-  if (T2 == GDF_DATE32)     { JOIN_HASH_T3(T1, l1, r1, int32_t, l2, r2, T3, l3, r3) } \
-  if (T2 == GDF_DATE64)     { JOIN_HASH_T3(T1, l1, r1, int64_t, l2, r2, T3, l3, r3) } \
-  if (T2 == GDF_TIMESTAMP)  { JOIN_HASH_T3(T1, l1, r1, int64_t, l2, r2, T3, l3, r3) }
-
-#define JOIN_HASH_T1(T1, l1, r1, T2, l2, r2, T3, l3, r3) \
-  if (T1 == GDF_INT8)      { JOIN_HASH_T2( int8_t, l1, r1, T2, l2, r2, T3, l3, r3) } \
-  if (T1 == GDF_INT16)     { JOIN_HASH_T2(int16_t, l1, r1, T2, l2, r2, T3, l3, r3) } \
-  if (T1 == GDF_INT32)     { JOIN_HASH_T2(int32_t, l1, r1, T2, l2, r2, T3, l3, r3) } \
-  if (T1 == GDF_INT64)     { JOIN_HASH_T2(int64_t, l1, r1, T2, l2, r2, T3, l3, r3) } \
-  if (T1 == GDF_FLOAT32)   { JOIN_HASH_T2(int32_t, l1, r1, T2, l2, r2, T3, l3, r3) } \
-  if (T1 == GDF_FLOAT64)   { JOIN_HASH_T2(int64_t, l1, r1, T2, l2, r2, T3, l3, r3) } \
-  if (T1 == GDF_DATE32)    { JOIN_HASH_T2(int32_t, l1, r1, T2, l2, r2, T3, l3, r3) } \
-  if (T1 == GDF_DATE64)    { JOIN_HASH_T2(int64_t, l1, r1, T2, l2, r2, T3, l3, r3) } \
-  if (T1 == GDF_TIMESTAMP) { JOIN_HASH_T2(int64_t, l1, r1, T2, l2, r2, T3, l3, r3) }
-
-// multi-column join function
-template <JoinType join_type>
-gdf_error multi_column_join(int num_cols, gdf_column **leftcol, gdf_column **rightcol, gdf_join_result_type **out_result)
+/* --------------------------------------------------------------------------*/
+/** 
+ * @Synopsis Computes the Join result between two tables using the hash-based implementation. 
+ * 
+ * @Param num_cols The number of columns to join
+ * @Param leftcol The left set of columns to join
+ * @Param rightcol The right set of columns to join
+ * @Param out_result The result of the join operation. The first n/2 elements of the
+   output are the left indices, the last n/2 elements of the output are the right indices.
+   @tparam join_type The type of join to be performed
+ * 
+ * @Returns Upon successful computation, returns GDF_SUCCESS. Otherwise returns appropriate error code 
+ */
+/* ----------------------------------------------------------------------------*/
+template <JoinType join_type, 
+          typename size_type>
+gdf_error hash_join(size_type num_cols, gdf_column **leftcol, gdf_column **rightcol, gdf_join_result_type **out_result)
 {
-  // check that the columns have matching types and the same number of rows
-  for (int i = 0; i < num_cols; i++) {
-    if (rightcol[i]->dtype != leftcol[i]->dtype) return GDF_JOIN_DTYPE_MISMATCH;
-    if (i > 0 && leftcol[i]->size != leftcol[i-1]->size) return GDF_COLUMN_SIZE_MISMATCH;
-    if (i > 0 && rightcol[i]->size != rightcol[i-1]->size) return GDF_COLUMN_SIZE_MISMATCH;
-  }
+  // Wrap the set of gdf_columns in a gdf_table class
+  std::unique_ptr< gdf_table<size_type> > left_table(new gdf_table<size_type>(num_cols, leftcol));
+  std::unique_ptr< gdf_table<size_type> > right_table(new gdf_table<size_type>(num_cols, rightcol));
 
-  // TODO: currently support up to 3 columns
-  if (num_cols > 3) return GDF_JOIN_TOO_MANY_COLUMNS;
-  for (int i = 0; i < num_cols; i++) {
-    if (leftcol[i]->dtype == N_GDF_TYPES ) return GDF_UNSUPPORTED_DTYPE;
-  }
+  std::unique_ptr< join_result<output_type> > result_ptr(new join_result<output_type>);
 
-  std::unique_ptr<join_result<int> > result_ptr(new join_result<int>);
-  switch (num_cols) {
-  case 1:
-    JOIN_HASH_T1(leftcol[0]->dtype, leftcol[0]->data, rightcol[0]->data,
-		 GDF_INT32, NULL, NULL,
-		 GDF_INT32, NULL, NULL)
-    break;
-  case 2:
-    JOIN_HASH_T1(leftcol[0]->dtype, leftcol[0]->data, rightcol[0]->data,
-		 leftcol[1]->dtype, leftcol[1]->data, rightcol[1]->data,
-		 GDF_INT32, NULL, NULL)
-    break;
-  case 3:
-    JOIN_HASH_T1(leftcol[0]->dtype, leftcol[0]->data, rightcol[0]->data,
-		 leftcol[1]->dtype, leftcol[1]->data, rightcol[1]->data,
-		 leftcol[2]->dtype, leftcol[2]->data, rightcol[2]->data)
-    break;
-  }
+  result_ptr->result = join_hash<join_type, output_type>(*left_table, *right_table, result_ptr->context);
 
   CUDA_CHECK_LAST();
   *out_result = cffi_wrap(result_ptr.release());
@@ -185,7 +141,7 @@ struct SortJoin {
 template<typename launch_arg_t = mgpu::empty_t,
   typename a_it, typename b_it, typename comp_t>
     mgpu::mem_t<int> operator()(a_it a, int a_count, b_it b, int b_count,
-                       comp_t comp, context_t& context) {
+                                 comp_t comp, context_t& context) {
         return mem_t<int>();
     }
 };
@@ -195,95 +151,161 @@ struct SortJoin<JoinType::INNER_JOIN> {
 template<typename launch_arg_t = mgpu::empty_t,
   typename a_it, typename b_it, typename comp_t>
     mgpu::mem_t<int> operator()(a_it a, int a_count, b_it b, int b_count,
-                       comp_t comp, context_t& context) {
+                                 comp_t comp, context_t& context) {
         return inner_join(a, a_count, b, b_count, comp, context);
     }
 };
 
 template <>
 struct SortJoin<JoinType::LEFT_JOIN> {
-template<typename launch_arg_t = mgpu::empty_t,
-  typename a_it, typename b_it, typename comp_t>
-    mgpu::mem_t<int> operator()(a_it a, int a_count, b_it b, int b_count,
-                       comp_t comp, context_t& context) {
+  template<typename launch_arg_t = mgpu::empty_t,
+    typename a_it, typename b_it, typename comp_t>
+      mgpu::mem_t<int> operator()(a_it a, int a_count, b_it b, int b_count,
+                                  comp_t comp, context_t& context) {
         return left_join(a, a_count, b, b_count, comp, context);
-    }
+      }
 };
 
 template <JoinType join_type, typename T>
-gdf_error single_column_join_typed(gdf_column *leftcol, gdf_column *rightcol,
-                             gdf_join_result_type **out_result, gdf_context *ctxt) {
-    using namespace mgpu;
-    gdf_error err = GDF_SUCCESS;
-    if ( leftcol->dtype != rightcol->dtype) return GDF_UNSUPPORTED_DTYPE;
-    if ( leftcol->size >= MAX_JOIN_SIZE ) return GDF_COLUMN_SIZE_TOO_BIG;
-    if ( rightcol->size >= MAX_JOIN_SIZE ) return GDF_COLUMN_SIZE_TOO_BIG;
-    std::unique_ptr<join_result<int> > result_ptr(new join_result<int>);
-    if (N_GDF_METHODS == ctxt->flag_method) {
-    err = GDF_UNSUPPORTED_METHOD;
-    } else if (GDF_SORT == ctxt->flag_method) {
-    SortJoin<join_type> join;
-    result_ptr->result = join((T*)leftcol->data, leftcol->size,
-                                (T*)rightcol->data, rightcol->size,
-                                less_t<T>(), result_ptr->context);
-    CUDA_CHECK_LAST();
-    *out_result = cffi_wrap(result_ptr.release());
-    } else if (GDF_HASH == ctxt->flag_method) {
-    result_ptr->result = join_hash<join_type>((T*)leftcol->data, (int)leftcol->size,
-                                (T*)rightcol->data, (int)rightcol->size,
-				(int32_t*)NULL, (int32_t*)NULL,
-				(int32_t*)NULL, (int32_t*)NULL,
-                                less_t<T>(), result_ptr->context);
-    CUDA_CHECK_LAST();
-    *out_result = cffi_wrap(result_ptr.release());
-    }
-    return err;
+gdf_error sort_join_typed(gdf_column *leftcol, gdf_column *rightcol,
+                          gdf_join_result_type **out_result, gdf_context *ctxt) 
+{
+  using namespace mgpu;
+  gdf_error err = GDF_SUCCESS;
+
+  std::unique_ptr<join_result<int> > result_ptr(new join_result<int>);
+
+  SortJoin<join_type> sort_based_join;
+  result_ptr->result = sort_based_join(static_cast<T*>(leftcol->data), leftcol->size,
+                                       static_cast<T*>(rightcol->data), rightcol->size,
+                                       less_t<T>(), result_ptr->context);
+  CUDA_CHECK_LAST();
+  *out_result = cffi_wrap(result_ptr.release());
+
+  return err;
 }
 
+/* --------------------------------------------------------------------------*/
+/** 
+ * @Synopsis  Computes the join operation between a single left and single right column
+ using the sort based implementation.
+ * 
+ * @Param leftcol The left column to join
+ * @Param rightcol The right column to join
+ * @Param out_result The output of the join operation
+ * @Param ctxt Structure that determines various run parameters, such as if the inputs
+ are already sorted.
+   @tparama join_type The type of join to perform
+ * 
+ * @Returns GDF_SUCCESS upon succesful completion of the join, otherwise returns 
+ appropriate error code.
+ */
+/* ----------------------------------------------------------------------------*/
 template <JoinType join_type>
-gdf_error single_column_join(gdf_column *leftcol, gdf_column *rightcol,
-                             gdf_join_result_type **out_result, gdf_context *ctxt) {
-    switch ( leftcol->dtype ){
-    case GDF_INT8:    return single_column_join_typed<join_type, int8_t>(leftcol, rightcol, out_result, ctxt);
-    case GDF_INT16:   return single_column_join_typed<join_type,int16_t>(leftcol, rightcol, out_result, ctxt);
-    case GDF_INT32:   return single_column_join_typed<join_type,int32_t>(leftcol, rightcol, out_result, ctxt);
-    case GDF_INT64:   return single_column_join_typed<join_type,int64_t>(leftcol, rightcol, out_result, ctxt);
-    case GDF_FLOAT32: return single_column_join_typed<join_type,int32_t>(leftcol, rightcol, out_result, ctxt);
-    case GDF_FLOAT64: return single_column_join_typed<join_type,int64_t>(leftcol, rightcol, out_result, ctxt);
+gdf_error sort_join(gdf_column *leftcol, gdf_column *rightcol,
+                    gdf_join_result_type **out_result, gdf_context *ctxt) 
+{
+
+  if(GDF_SORT != ctxt->flag_method) return GDF_INVALID_API_CALL;
+
+  switch ( leftcol->dtype ){
+    case GDF_INT8:      return sort_join_typed<join_type, int8_t>(leftcol, rightcol, out_result, ctxt);
+    case GDF_INT16:     return sort_join_typed<join_type,int16_t>(leftcol, rightcol, out_result, ctxt);
+    case GDF_INT32:     return sort_join_typed<join_type,int32_t>(leftcol, rightcol, out_result, ctxt);
+    case GDF_INT64:     return sort_join_typed<join_type,int64_t>(leftcol, rightcol, out_result, ctxt);
+    case GDF_FLOAT32:   return sort_join_typed<join_type,int32_t>(leftcol, rightcol, out_result, ctxt);
+    case GDF_FLOAT64:   return sort_join_typed<join_type,int64_t>(leftcol, rightcol, out_result, ctxt);
+    case GDF_DATE32:    return sort_join_typed<join_type,int32_t>(leftcol, rightcol, out_result, ctxt);
+    case GDF_DATE64:    return sort_join_typed<join_type,int64_t>(leftcol, rightcol, out_result, ctxt);
+    case GDF_TIMESTAMP: return sort_join_typed<join_type,int64_t>(leftcol, rightcol, out_result, ctxt);
     default: return GDF_UNSUPPORTED_DTYPE;
-    }
+  }
 }
 
 template
-gdf_error single_column_join<JoinType::INNER_JOIN>(gdf_column *leftcol, gdf_column *rightcol,
+gdf_error sort_join<JoinType::INNER_JOIN>(gdf_column *leftcol, gdf_column *rightcol,
                              gdf_join_result_type **out_result, gdf_context *ctxt);
 template
-gdf_error single_column_join<JoinType::LEFT_JOIN>(gdf_column *leftcol, gdf_column *rightcol,
+gdf_error sort_join<JoinType::LEFT_JOIN>(gdf_column *leftcol, gdf_column *rightcol,
                              gdf_join_result_type **out_result, gdf_context *ctxt);
 
+/* --------------------------------------------------------------------------*/
+/** 
+ * @Synopsis  Computes the join operation between two sets of columns
+ * 
+ * @Param num_cols The number of columns to join
+ * @Param leftcol The left set of columns to join
+ * @Param rightcol The right set of columns to join
+ * @Param out_result The result of the join operation. The output is structured such that
+ * the pair (i, i + output_size/2) is the (left, right) index of matching rows.
+ * @Param join_context A structure that determines various run parameters, such as
+   whether to perform a hash or sort based join
+ * @tparam join_type The type of join to be performed
+ * 
+ * @Returns GDF_SUCCESS upon succesfull compute, otherwise returns appropriate error code
+ */
+/* ----------------------------------------------------------------------------*/
 template <JoinType join_type>
-gdf_error join_call(
-        int num_cols, gdf_column **leftcol, gdf_column **rightcol,
-                                 gdf_join_result_type **out_result, gdf_context *ctxt) {
-    if (num_cols > 1) {
-        if (GDF_HASH != ctxt->flag_method) {
-            return GDF_UNSUPPORTED_DTYPE;
-        } else {
-            return multi_column_join<join_type>(num_cols, leftcol, rightcol, out_result);
+gdf_error join_call( int num_cols, gdf_column **leftcol, gdf_column **rightcol,
+                     gdf_join_result_type **out_result, gdf_context *join_context) 
+{
+
+  if( (0 == num_cols) || (nullptr == leftcol) || (nullptr == rightcol))
+    return GDF_DATASET_EMPTY;
+
+  if(nullptr == join_context)
+    return GDF_INVALID_API_CALL;
+
+  // check that the columns data are not null, have matching types, 
+  // and the same number of rows
+  const auto left_col_size = leftcol[0]->size;
+  const auto right_col_size = rightcol[0]->size;
+  
+  if(left_col_size >= MAX_JOIN_SIZE) return GDF_COLUMN_SIZE_TOO_BIG;
+  if(right_col_size >= MAX_JOIN_SIZE) return GDF_COLUMN_SIZE_TOO_BIG;
+
+  for (int i = 0; i < num_cols; i++) {
+    if(nullptr == rightcol[i]->data) return GDF_DATASET_EMPTY;
+    if(nullptr == leftcol[i]->data) return GDF_DATASET_EMPTY;
+    if(rightcol[i]->dtype != leftcol[i]->dtype) return GDF_JOIN_DTYPE_MISMATCH;
+    if(left_col_size != leftcol[i]->size) return GDF_COLUMN_SIZE_MISMATCH;
+    if(right_col_size != rightcol[i]->size) return GDF_COLUMN_SIZE_MISMATCH;
+  }
+
+  gdf_method join_method = join_context->flag_method; 
+
+  switch(join_method)
+  {
+    case GDF_HASH:
+      {
+        return hash_join<join_type>(num_cols, leftcol, rightcol, out_result);
+      }
+    case GDF_SORT:
+      {
+        // Sort based joins only support single column joins
+        if(1 == num_cols)
+        {
+          return sort_join<join_type>(leftcol[0], rightcol[0], out_result, join_context);
         }
-    } else if (num_cols == 1) {
-        return single_column_join<join_type>(leftcol[0], rightcol[0], out_result, ctxt);
-    } else {
-        return GDF_UNSUPPORTED_METHOD;
-    }
+        else
+        {
+          return GDF_JOIN_TOO_MANY_COLUMNS;
+        }
+      }
+    default:
+      return GDF_UNSUPPORTED_METHOD;
+  }
+
 }
 
 gdf_error gdf_left_join(int num_cols, gdf_column **leftcol, gdf_column **rightcol,
-                                gdf_join_result_type **out_result, gdf_context *ctxt) {
-    return join_call<JoinType::LEFT_JOIN>(num_cols, leftcol, rightcol, out_result, ctxt);
+                        gdf_join_result_type **out_result, gdf_context *ctxt) 
+{
+  return join_call<JoinType::LEFT_JOIN>(num_cols, leftcol, rightcol, out_result, ctxt);
 }
 
 gdf_error gdf_inner_join(int num_cols, gdf_column **leftcol, gdf_column **rightcol,
-                                gdf_join_result_type **out_result, gdf_context *ctxt) {
-    return join_call<JoinType::INNER_JOIN>(num_cols, leftcol, rightcol, out_result, ctxt);
+                         gdf_join_result_type **out_result, gdf_context *ctxt) 
+{
+  return join_call<JoinType::INNER_JOIN>(num_cols, leftcol, rightcol, out_result, ctxt);
 }

--- a/src/sqls_ops.cu
+++ b/src/sqls_ops.cu
@@ -1164,7 +1164,6 @@ gdf_error gdf_group_by_single(int ncols,                    // # columns
                                              out_col_values,
                                              out_col_agg,
                                              sort_result);
-            break;
           }
         case GDF_MIN:
           {
@@ -1174,7 +1173,6 @@ gdf_error gdf_group_by_single(int ncols,                    // # columns
                                              out_col_values,
                                              out_col_agg,
                                              sort_result);
-            break;
           }
         case GDF_SUM:
           {

--- a/src/tests/hash_map/multimap-test.cu
+++ b/src/tests/hash_map/multimap-test.cu
@@ -17,6 +17,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <vector>
+#include <limits>
 
 #include <thrust/device_vector.h>
 
@@ -42,20 +43,22 @@ class MultimapTest : public testing::Test
 public:
   using key_type = typename T::key_type;
   using value_type = typename T::value_type;
+  using size_type = int;
 
 
   concurrent_unordered_multimap<key_type, 
                                 value_type, 
+                                size_type,
                                 std::numeric_limits<key_type>::max(),
                                 std::numeric_limits<value_type>::max() > the_map;
 
   const key_type unused_key = std::numeric_limits<key_type>::max();
   const value_type unused_value = std::numeric_limits<value_type>::max();
 
-  const int size;
+  const size_type size;
 
 
-  MultimapTest(const int hash_table_size = 100)
+  MultimapTest(const size_type hash_table_size = 100)
     : the_map(hash_table_size), size(hash_table_size)
   {
 


### PR DESCRIPTION
- Added gdf_table which inherits from managed class to be allocated with managed memory.
- Implemented a hash_combine function to combine two hash values.
- Refactored the join_hash function to operate on gdf_tables.
- Eliminated the InnerJoin and LeftJoin functions in favor of a single compute_hash_join function. Refactored the API to operate on gdf_tables.
- Added size_type as a template parameter to unordered_multimap.
- Updated the signature of the probe_hash_table function to work with new gdf_table structure.
- Added commented to probe_hash_table_uniq_keys kernel to indicate that it still needs to be updated to work with an arbitrary number of columns.
- Added date and timestamps for joins.
