### PR TITLE
[REVIEW] FIX Update Travis CI Script to Update apt Before libboost Install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
   - ./miniconda.sh -b
   - export PATH=$HOME/miniconda3/bin:$PATH
   # install libboost
-  - sudo apt-get udpate
+  - sudo apt-get update
   - sudo apt-get install -y libboost-all-dev
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,9 @@ before_install:
   - chmod +x miniconda.sh
   - ./miniconda.sh -b
   - export PATH=$HOME/miniconda3/bin:$PATH
+  # install libboost
+  - sudo apt-get udpate
+  - sudo apt-get install -y libboost-all-dev
 
 install:
   # check
@@ -34,8 +37,6 @@ install:
   - conda --version
   # install conda build
   - conda install conda-build anaconda-client conda-verify --yes
-  # install libboost
-  - sudo apt-get install libboost-all-dev
 
 script:
   # build ligdf


### PR DESCRIPTION
This should fix the errors we are seeing in Travis CI where builds fail due to `unknown package libboost-all-dev`

Notes:
* Also moving `libboost-all-dev` install to `before_install` as recommended by Travis CI docs