### PR TITLE
Add NVCC flag "-Werror cross-cross-execution-space-call" 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ if(CUDA_FOUND)
         -Wno-deprecated-declarations;
         -Xptxas --disable-warnings)
     # set warnings as errors
-    set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};-Xcompiler -Wall,-Werror)
+    set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};-Werror cross-execution-space-call;-Xcompiler -Wall,-Werror)
 
     message(STATUS "CUDA_NVCC_FLAGS: ${CUDA_NVCC_FLAGS}")
 else()

--- a/src/tests/groupby/groupby-kernels-test.cu
+++ b/src/tests/groupby/groupby-kernels-test.cu
@@ -393,7 +393,7 @@ TYPED_TEST(GroupByTest, DISABLED_AggregationTestHost)
   thrust::pair<key_type, value_type> third_pair{0,5};
 
   struct {
-    __device__ value_type operator()(value_type a, value_type b) { return (a >= b ? a : b); };
+    __host__ __device__ value_type operator()(value_type a, value_type b) { return (a >= b ? a : b); };
   } maxop;
 
   this->the_map->insert(first_pair, maxop);


### PR DESCRIPTION
I missed this flag in the now-merged #117 

This flag makes calling a __host__ function from a __device__ function an error rather than a warning.

Please merge ASAP.