### PR TITLE
[REVIEW] Only build CFFI on CUDA 9.0, only upload to Anaconda for CUDA 9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ matrix:
     - env: CUDA=9.0.176_384.81
     - env: CUDA=9.1.85_387.26
     - env: CUDA=9.2.148_396.37
-    - env: CUDA=9.2.148_396.37 BUILD_CFFI=1 PYTHON=3.6
-    - env: CUDA=9.2.148_396.37 BUILD_CFFI=1 PYTHON=3.5
+    - env: CUDA=9.0.176_384.81 BUILD_CFFI=1 PYTHON=3.6
+    - env: CUDA=9.0.176_384.81 BUILD_CFFI=1 PYTHON=3.5
     
 
 before_install:

--- a/travisci/upload.sh
+++ b/travisci/upload.sh
@@ -10,3 +10,4 @@ if [ ${CUDA:0:3} == '9.0' ]
     echo "UPLOADFILE = ${UPLOADFILE}"
     test -e ${UPLOADFILE}
     source ./travisci/upload-anaconda.sh
+fi

--- a/travisci/upload.sh
+++ b/travisci/upload.sh
@@ -6,6 +6,7 @@ else
     export UPLOADFILE=`conda build conda-recipes/libgdf -c defaults -c conda-forge --output`
 fi
 
-echo "UPLOADFILE = ${UPLOADFILE}"
-test -e ${UPLOADFILE}
-source ./travisci/upload-anaconda.sh
+if [ ${CUDA:0:3} == '9.0' ]
+    echo "UPLOADFILE = ${UPLOADFILE}"
+    test -e ${UPLOADFILE}
+    source ./travisci/upload-anaconda.sh

--- a/travisci/upload.sh
+++ b/travisci/upload.sh
@@ -1,3 +1,7 @@
+#!/bin/bash
+#
+# Copyright (c) 2018, NVIDIA CORPORATION.
+
 set -e
 
 if [ $BUILD_CFFI == 1 ]; then

--- a/travisci/upload.sh
+++ b/travisci/upload.sh
@@ -10,7 +10,7 @@ else
     export UPLOADFILE=`conda build conda-recipes/libgdf -c defaults -c conda-forge --output`
 fi
 
-if [ ${CUDA:0:3} == '9.0' ]
+if [ ${CUDA:0:3} == '9.0' ]; then
     echo "UPLOADFILE = ${UPLOADFILE}"
     test -e ${UPLOADFILE}
     source ./travisci/upload-anaconda.sh


### PR DESCRIPTION
Since CUDA 9.0 builds are forward compatible, but CUDA 9.2 builds aren't necessarily backwards compatible, should only publish CUDA 9.0 builds.