### PR TITLE
[REVIEW] Fixes truncation warning in multimap template parameters

### DIFF
--- a/src/join/hash/join_compute_api.h
+++ b/src/join/hash/join_compute_api.h
@@ -219,7 +219,7 @@ gdf_error compute_hash_join(mgpu::context_t & compute_ctx,
                                                       output_index_type,
                                                       size_type,
                                                       std::numeric_limits<hash_value_type>::max(),
-                                                      std::numeric_limits<size_type>::max()>;
+                                                      std::numeric_limits<output_index_type>::max()>;
 #endif
 
   // Hash table will be built on the right table

--- a/src/join/hash/join_compute_api.h
+++ b/src/join/hash/join_compute_api.h
@@ -183,6 +183,7 @@ gdf_error estimate_join_output_size(gdf_table<size_type> const & build_table,
 * @tparam join_type The type of join to be performed
 * @tparam hash_value_type The data type to be used for the Keys in the hash table
 * @tparam output_index_type The data type to be used for the output indices
+* @tparam size_type The data type used for size calculations, e.g. size of hash table
 *
 * @Returns  cudaSuccess upon successful completion of the join. Otherwise returns
 * the appropriate CUDA error code


### PR DESCRIPTION
…incorrect type. This resolves https://github.com/gpuopenanalytics/libgdf/issues/127.

<!--

Thanks for wanting to contribute to libGDF :)

First, if you need some help or want to chat to the core developers, please
visit http://gpuopenanalytics.com/#/COMMUNITY for links to Slack and Google
Groups.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label and replace it with `[REVIEW]` when you'd like it to
   be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

This fixes https://github.com/gpuopenanalytics/libgdf/issues/127

The multimap class's template parameter for the `unused_value` was being set incorrectly to use the `size_type` instead of the value type `output_index_type`.
