### PR TITLE
[WIP] Replace CUDA_RT_MACRO that calls exit() on CUDA errors

### DIFF
--- a/src/hashmap/concurrent_unordered_map.cuh
+++ b/src/hashmap/concurrent_unordered_map.cuh
@@ -628,7 +628,7 @@ public:
         return const_iterator( m_hashtbl_values,m_hashtbl_values+m_hashtbl_size,begin_ptr);
     }
     
-    void assign_async( const concurrent_unordered_map& other, cudaStream_t stream = 0 )
+    gdf_error assign_async( const concurrent_unordered_map& other, cudaStream_t stream = 0 )
     {
         m_collisions = other.m_collisions;
         if ( other.m_hashtbl_size <= m_hashtbl_capacity ) {
@@ -640,7 +640,8 @@ public:
             
             m_hashtbl_values = m_allocator.allocate( m_hashtbl_capacity );
         }
-        CUDA_RT_CALL( cudaMemcpyAsync( m_hashtbl_values, other.m_hashtbl_values, m_hashtbl_size*sizeof(value_type), cudaMemcpyDefault, stream ) );
+        CUDA_TRY( cudaMemcpyAsync( m_hashtbl_values, other.m_hashtbl_values, m_hashtbl_size*sizeof(value_type), cudaMemcpyDefault, stream ) );
+        return GDF_SUCCESS;
     }
     
     void clear_async( cudaStream_t stream = 0 ) 
@@ -664,15 +665,17 @@ public:
         }
     }
     
-    void prefetch( const int dev_id, cudaStream_t stream = 0 )
+    gdf_error prefetch( const int dev_id, cudaStream_t stream = 0 )
     {
         cudaPointerAttributes hashtbl_values_ptr_attributes;
         cudaError_t status = cudaPointerGetAttributes( &hashtbl_values_ptr_attributes, m_hashtbl_values );
         
         if ( cudaSuccess == status && hashtbl_values_ptr_attributes.isManaged ) {
-            CUDA_RT_CALL( cudaMemPrefetchAsync(m_hashtbl_values, m_hashtbl_size*sizeof(value_type), dev_id, stream) );
+            CUDA_TRY( cudaMemPrefetchAsync(m_hashtbl_values, m_hashtbl_size*sizeof(value_type), dev_id, stream) );
         }
-        CUDA_RT_CALL( cudaMemPrefetchAsync(this, sizeof(*this), dev_id, stream) );
+        CUDA_TRY( cudaMemPrefetchAsync(this, sizeof(*this), dev_id, stream) );
+
+        return GDF_SUCCESS;
     }
     
 private:

--- a/src/hashmap/concurrent_unordered_map.cuh
+++ b/src/hashmap/concurrent_unordered_map.cuh
@@ -21,6 +21,7 @@
 #include <type_traits>
 #include <cassert>
 #include <iostream>
+#include <gdf/gdf.h>
 
 #include <thrust/pair.h>
 

--- a/src/hashmap/concurrent_unordered_multimap.cuh
+++ b/src/hashmap/concurrent_unordered_multimap.cuh
@@ -532,7 +532,7 @@ public:
         return const_iterator( m_hashtbl_values,m_hashtbl_values+m_hashtbl_size,begin_ptr);
     }
     
-    void assign_async( const concurrent_unordered_multimap& other, cudaStream_t stream = 0 )
+    gdf_error assign_async( const concurrent_unordered_multimap& other, cudaStream_t stream = 0 )
     {
         m_collisions = other.m_collisions;
         if ( other.m_hashtbl_size <= m_hashtbl_capacity ) {
@@ -544,7 +544,9 @@ public:
             
             m_hashtbl_values = m_allocator.allocate( m_hashtbl_capacity );
         }
-        CUDA_RT_CALL( cudaMemcpyAsync( m_hashtbl_values, other.m_hashtbl_values, m_hashtbl_size*sizeof(value_type), cudaMemcpyDefault, stream ) );
+        CUDA_TRY( cudaMemcpyAsync( m_hashtbl_values, other.m_hashtbl_values, m_hashtbl_size*sizeof(value_type), cudaMemcpyDefault, stream ) );
+
+        return GDF_SUCCESS;
     }
     
     void clear_async( cudaStream_t stream = 0 ) 
@@ -568,15 +570,16 @@ public:
         }
     }
     
-    void prefetch( const int dev_id, cudaStream_t stream = 0 )
+    gdf_error prefetch( const int dev_id, cudaStream_t stream = 0 )
     {
         cudaPointerAttributes hashtbl_values_ptr_attributes;
         cudaError_t status = cudaPointerGetAttributes( &hashtbl_values_ptr_attributes, m_hashtbl_values );
         
         if ( cudaSuccess == status && hashtbl_values_ptr_attributes.isManaged ) {
-            CUDA_RT_CALL( cudaMemPrefetchAsync(m_hashtbl_values, m_hashtbl_size*sizeof(value_type), dev_id, stream) );
+            CUDA_TRY( cudaMemPrefetchAsync(m_hashtbl_values, m_hashtbl_size*sizeof(value_type), dev_id, stream) );
         }
-        CUDA_RT_CALL( cudaMemPrefetchAsync(this, sizeof(*this), dev_id, stream) );
+        CUDA_TRY( cudaMemPrefetchAsync(this, sizeof(*this), dev_id, stream) );
+        return GDF_SUCCESS;
     }
     
 private:

--- a/src/hashmap/concurrent_unordered_multimap.cuh
+++ b/src/hashmap/concurrent_unordered_multimap.cuh
@@ -21,6 +21,7 @@
 #include <iterator>
 #include <type_traits>
 #include <cassert>
+#include <gdf/gdf.h>
 
 #include <thrust/pair.h>
 


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to libGDF :)

First, if you need some help or want to chat to the core developers, please
visit http://gpuopenanalytics.com/#/COMMUNITY for links to Slack and Google
Groups.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label and replace it with `[REVIEW]` when you'd like it to
   be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

In order to resolve Issue https://github.com/gpuopenanalytics/libgdf/issues/102, this PR will remove the `CUDA_RT_CALL` that calls exit() when a CUDA error is encountered.

Instead, it will be replaced with `CUDA_TRY` that returns a `GDF_CUDA_ERROR` error code that can be passed up to the original call site. 

However, returning an error code from a class constructor is not possible. Therefore, we likely need to throw an Exception when a CUDA error is encountered in a constructor. Exceptions are problematic because the pygdf side can't do exception handling since CFFI is a C interface. 

Fully eliminating `CUDA_RT_CALL` may require waiting until CFFI is replaced with a C++ interface that can do exception handling.
