### PR TITLE
[REVIEW] Resolved potential memory leak in hash Joins 

### DIFF
--- a/src/join/hash/join_compute_api.h
+++ b/src/join/hash/join_compute_api.h
@@ -343,6 +343,8 @@ gdf_error compute_hash_join(mgpu::context_t & compute_ctx,
     if(estimated_join_output_size < h_actual_found){
       cont = true;
       estimated_join_output_size *= 2;
+      CUDA_TRY( cudaFree(output_l_ptr) );
+      CUDA_TRY( cudaFree(output_r_ptr) );
     }
     else
     {

--- a/src/join/hash/join_compute_api.h
+++ b/src/join/hash/join_compute_api.h
@@ -343,6 +343,7 @@ gdf_error compute_hash_join(mgpu::context_t & compute_ctx,
     if(estimated_join_output_size < h_actual_found){
       cont = true;
       estimated_join_output_size *= 2;
+      // Free the old buffers to prevent a memory leak on the new allocation
       CUDA_TRY( cudaFree(output_l_ptr) );
       CUDA_TRY( cudaFree(output_r_ptr) );
     }


### PR DESCRIPTION
The buffers for the Join output are allocated in a loop because we may not know the exact size of the output and may need to reallocate the buffers and try again. 

However, in the case that we need to try again, we weren't freeing the previous buffers, which would result in a memory leak. 

This PR fixes the issue by freeing the memory if we need to double the buffer size and try again. 

<!--

Thanks for wanting to contribute to libGDF :)

First, if you need some help or want to chat to the core developers, please
visit http://gpuopenanalytics.com/#/COMMUNITY for links to Slack and Google
Groups.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label and replace it with `[REVIEW]` when you'd like it to
   be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
