### PR TITLE
[REVIEW] Finalizes hash-join NULL support

### DIFF
--- a/include/gdf/errorutils.h
+++ b/include/gdf/errorutils.h
@@ -11,10 +11,10 @@
     if ( cudaSuccess != cudaStatus )                                  \
     {                                                                 \
         std::cerr << "ERROR: CUDA Runtime call " << #call             \
-                  << "in line" << __LINE__                            \
-                  << "of file" << __FILE__                            \
-                  << "failed with" << cudaGetErrorString(cudaStatus)  \
-                  << "(" << cudaStatus << ").\n";                     \
+                  << " in line " << __LINE__                            \
+                  << " of file " << __FILE__                            \
+                  << " failed with " << cudaGetErrorString(cudaStatus)  \
+                  << " (" << cudaStatus << ").\n";                     \
         return GDF_CUDA_ERROR;                          							\
     }												                                          \
 }                                                                                                  

--- a/include/gdf/utils.h
+++ b/include/gdf/utils.h
@@ -3,7 +3,7 @@
 
 #include <gdf/gdf.h>
 
-__device__
+__host__ __device__
 static
 bool gdf_is_valid(const gdf_valid_type *valid, gdf_index_type pos) {
 	if ( valid )

--- a/src/gdf_table.cuh
+++ b/src/gdf_table.cuh
@@ -18,12 +18,12 @@
 #define GDF_TABLE_H
 
 #include <gdf/gdf.h>
+#include <gdf/utils.h>
 #include <thrust/device_vector.h>
 #include <cassert>
 #include <gdf/errorutils.h>
 #include "hashmap/hash_functions.cuh"
 #include "hashmap/managed.cuh"
-#include "util/bit_util.cuh"
 
 /* --------------------------------------------------------------------------*/
 /** 
@@ -130,7 +130,7 @@ public:
 
     // Allocate storage sufficient to hold a validity bit for every row
     // in the table
-    const size_type mask_size = gdf::util::valid_size(column_length);
+    const size_type mask_size = gdf_get_num_chars_bitmask(column_length);
     device_row_valid.resize(mask_size);
 
     // If a row contains a single NULL value, then the entire row is considered
@@ -166,7 +166,7 @@ public:
 
   __device__ bool is_row_valid(size_type row_index) const
   {
-    const bool row_valid = gdf::util::get_bit(d_row_valid, row_index);
+    const bool row_valid = gdf_is_valid(d_row_valid, row_index);
 
     return row_valid;
   }

--- a/src/gdf_table.cuh
+++ b/src/gdf_table.cuh
@@ -72,6 +72,20 @@ struct row_masker
   gdf_valid_type ** column_valid_masks;
 };
 
+
+
+
+/* --------------------------------------------------------------------------*/
+/** 
+ * @Synopsis A class provides useful functionality for operating on a set of gdf_columns. 
+
+    The gdf_table class is meant to wrap a set of gdf_columns and provide functions
+    for operating across all of the columns. It can be thought of as a `matrix`
+    whose columns can be of different data types. Thinking of it as a matrix,
+    many row-wise operations are defined, such as checking if two rows in a table
+    are equivalent.
+ */
+/* ----------------------------------------------------------------------------*/
 template <typename T>
 class gdf_table : public managed
 {

--- a/src/join/hash/join_kernels.cuh
+++ b/src/join/hash/join_kernels.cuh
@@ -52,7 +52,11 @@ __global__ void build_hash_table( multimap_type * const multi_map,
     size_type i = threadIdx.x + blockIdx.x * blockDim.x;
 
     while( i < build_table_num_rows) {
+
+      // It is impossible for a row with a NULL value to match any other row,
+      // therefore, do not insert it into the hash table
       if (build_table.is_row_valid(i)) {
+
         // Compute the hash value of this row
         const hash_value_type row_hash_value{build_table.hash_row(i)};
 

--- a/src/join/hash/join_kernels.cuh
+++ b/src/join/hash/join_kernels.cuh
@@ -145,28 +145,25 @@ __global__ void compute_join_output_size( multimap_type const * const multi_map,
 
   size_type probe_row_index = threadIdx.x + blockIdx.x * blockDim.x;
 
- const bool predicate = (JoinType::LEFT_JOIN || probe_table.is_row_valid(probe_row_index)) 
-                         && (probe_row_index < probe_table_num_rows);             
-
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 9000
-  const unsigned int activemask = __ballot_sync(0xffffffff, predicate );
+  const unsigned int activemask = __ballot_sync(0xffffffff, probe_row_index < probe_table_num_rows);
 #endif
-  if ( predicate ) {
+  if ( probe_row_index < probe_table_num_rows ) {
     const auto unused_key = multi_map->get_unused_key();
     const auto end = multi_map->end();
+    auto found = end;
 
     // Search the hash map for the hash value of the probe row using the row's
     // hash value to determine the location where to search for the row in the hash map
-    // Only probe the hash table if the row is valid
+    // Only probe the hash table if the probe row is valid
     hash_value_type probe_row_hash_value{0};
-    auto found = multi_map->end();
     if(probe_table.is_row_valid(probe_row_index))
     {
       // Search the hash map for the hash value of the probe row
-      probe_row_hash_value = probe_table.hash_row(probe_row_index)};
+      probe_row_hash_value = probe_table.hash_row(probe_row_index);
       found = multi_map->find(probe_row_hash_value,
-                                   true,
-                                   probe_row_hash_value);
+                              true,
+                              probe_row_hash_value);
     }
 
     // for left-joins we always need to add an output
@@ -301,24 +298,24 @@ __global__ void probe_hash_table( multimap_type const * const multi_map,
 
   output_index_type probe_row_index = threadIdx.x + blockIdx.x * blockDim.x;
 
-// For left-joins, always add an output even if the probe row is Null
-const bool predicate = (JoinType::LEFT_JOIN || probe_table.is_row_valid(probe_row_index)) 
-                        && (probe_row_index < probe_table_num_rows);             
-
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 9000
-  const unsigned int activemask = __ballot_sync(0xffffffff, predicate );
+  const unsigned int activemask = __ballot_sync(0xffffffff, probe_row_index < probe_table_num_rows);
 #endif
-  if ( predicate ) {
-        
+  if ( probe_row_index < probe_table_num_rows ) {
+
     const auto unused_key = multi_map->get_unused_key();
     const auto end = multi_map->end();  
-    auto found = multi_map->end();    
-    // Only probe the hash table if the row is valid
+    auto found = end;    
+
+    // Search the hash map for the hash value of the probe row using the row's
+    // hash value to determine the location where to search for the row in the hash map
+
+    // Only probe the hash table if the probe row is valid
     hash_value_type probe_row_hash_value{0};
     if(probe_table.is_row_valid(probe_row_index))
     {
       // Search the hash map for the hash value of the probe row
-      probe_row_hash_value = probe_table.hash_row(probe_row_index)};
+      probe_row_hash_value = probe_table.hash_row(probe_row_index);
       found = multi_map->find(probe_row_hash_value,
                                    true,
                                    probe_row_hash_value);
@@ -330,98 +327,102 @@ const bool predicate = (JoinType::LEFT_JOIN || probe_table.is_row_valid(probe_ro
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 9000
     while ( __any_sync( activemask, running ) )
 #else
-      while ( __any( running ) )
+    while ( __any( running ) )
 #endif
+    {
+      if ( running )
       {
-        if ( running )
+        // TODO Simplify this logic...
+
+        // Left joins always have an entry in the output
+        if (join_type == JoinType::LEFT_JOIN && (end == found)) {
+          running = false;    
+        }
+        // Stop searching after encountering an empty hash table entry
+        else if ( unused_key == found->first ) {
+          running = false;
+        }
+        // First check that the hash values of the two rows match
+        else if (found->first == probe_row_hash_value)
         {
-          // TODO Simplify this logic...
-
-          // Left joins always have an entry in the output
-          if (join_type == JoinType::LEFT_JOIN && (end == found)) {
-            running = false;    
-          }
-          // Stop searching after encountering an empty hash table entry
-          else if ( unused_key == found->first ) {
-            running = false;
-          }
-          // First check that the hash values of the two rows match
-          else if (found->first == probe_row_hash_value)
+          // If the hash values are equal, check that the rows are equal
+          if( true == probe_table.rows_equal(build_table, probe_row_index, found->second) )
           {
-            // If the hash values are equal, check that the rows are equal
-            if( true == probe_table.rows_equal(build_table, probe_row_index, found->second) )
-            {
-              // If the rows are equal, then we have found a true match
-              found_match = true;
-              const output_index_type probe_index{offset + probe_row_index};
-              add_pair_to_cache(probe_index, found->second, current_idx_shared, warp_id, join_shared_l[warp_id], join_shared_r[warp_id]);
-            }
-            // Continue searching for matching rows until you hit an empty hash map entry
-            ++found;
-            // If you hit the end of the hash map, wrap around to the beginning
-            if(end == found)
-              found = multi_map->begin();
-            // Next entry is empty, stop searching
-            if(unused_key == found->first)
-              running = false;
-          }
-          else 
-          {
-            // Continue searching for matching rows until you hit an empty hash table entry
-            ++found;
-            // If you hit the end of the hash map, wrap around to the beginning
-            if(end == found)
-              found = multi_map->begin();
-            // Next entry is empty, stop searching
-            if(unused_key == found->first)
-              running = false;
-          }
 
-          // If performing a LEFT join and no match was found, insert a Null into the output
-          if ((join_type == JoinType::LEFT_JOIN) && (!running) && (!found_match)) {
+            // If the rows are equal, then we have found a true match
+            found_match = true;
             const output_index_type probe_index{offset + probe_row_index};
-            add_pair_to_cache(probe_index, static_cast<output_index_type>(JoinNoneValue), current_idx_shared, warp_id, join_shared_l[warp_id], join_shared_r[warp_id]);
+            add_pair_to_cache(probe_index, found->second, current_idx_shared, warp_id, join_shared_l[warp_id], join_shared_r[warp_id]);
           }
+          // Continue searching for matching rows until you hit an empty hash map entry
+          ++found;
+          // If you hit the end of the hash map, wrap around to the beginning
+          if(end == found)
+            found = multi_map->begin();
+          // Next entry is empty, stop searching
+          if(unused_key == found->first)
+            running = false;
+        }
+        else 
+        {
+          // Continue searching for matching rows until you hit an empty hash table entry
+          ++found;
+          // If you hit the end of the hash map, wrap around to the beginning
+          if(end == found)
+            found = multi_map->begin();
+          // Next entry is empty, stop searching
+          if(unused_key == found->first)
+            running = false;
         }
 
+        // If performing a LEFT join and no match was found, insert a Null into the output
+        if ((join_type == JoinType::LEFT_JOIN) && (!running) && (!found_match)) {
+          const output_index_type probe_index{offset + probe_row_index};
+          add_pair_to_cache(probe_index, static_cast<output_index_type>(JoinNoneValue), current_idx_shared, warp_id, join_shared_l[warp_id], join_shared_r[warp_id]);
+        }
+      }
+
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 9000
+      __syncwarp(activemask);
+#endif
+      //flush output cache if next iteration does not fit
+      if ( current_idx_shared[warp_id] + warp_size >= output_cache_size ) 
+      {
+
+        // count how many active threads participating here which could be less than warp_size
+#if defined(CUDA_VERSION) && CUDA_VERSION < 9000
+        const unsigned int activemask = __ballot(1);
+#endif
+        int num_threads = __popc(activemask);
+        size_type output_offset = 0;
+
+        if ( 0 == lane_id )
+        {
+          output_offset = atomicAdd( current_idx, current_idx_shared[warp_id] );
+        }
+
+        output_offset = cub::ShuffleIndex(output_offset, 0, warp_size, activemask);
+
+        for ( int shared_out_idx = lane_id; shared_out_idx<current_idx_shared[warp_id]; shared_out_idx+=num_threads ) 
+        {
+          size_type thread_offset = output_offset + shared_out_idx;
+          if (thread_offset < max_size) {
+            output_l[thread_offset] = join_shared_l[warp_id][shared_out_idx];
+            output_r[thread_offset] = join_shared_r[warp_id][shared_out_idx];
+          }
+        }
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 9000
         __syncwarp(activemask);
 #endif
-        //flush output cache if next iteration does not fit
-        if ( current_idx_shared[warp_id] + warp_size >= output_cache_size ) {
-
-          // count how many active threads participating here which could be less than warp_size
-#if defined(CUDA_VERSION) && CUDA_VERSION < 9000
-          const unsigned int activemask = __ballot(1);
-#endif
-          int num_threads = __popc(activemask);
-          size_type output_offset = 0;
-
-          if ( 0 == lane_id )
-          {
-            output_offset = atomicAdd( current_idx, current_idx_shared[warp_id] );
-          }
-
-          output_offset = cub::ShuffleIndex(output_offset, 0, warp_size, activemask);
-
-          for ( int shared_out_idx = lane_id; shared_out_idx<current_idx_shared[warp_id]; shared_out_idx+=num_threads ) 
-          {
-            size_type thread_offset = output_offset + shared_out_idx;
-            if (thread_offset < max_size) {
-              output_l[thread_offset] = join_shared_l[warp_id][shared_out_idx];
-              output_r[thread_offset] = join_shared_r[warp_id][shared_out_idx];
-            }
-          }
-#if defined(CUDA_VERSION) && CUDA_VERSION >= 9000
-          __syncwarp(activemask);
-#endif
-          if ( 0 == lane_id )
-            current_idx_shared[warp_id] = 0;
-#if defined(CUDA_VERSION) && CUDA_VERSION >= 9000
-          __syncwarp(activemask);
-#endif
+        if ( 0 == lane_id )
+        {
+          current_idx_shared[warp_id] = 0;
         }
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 9000
+        __syncwarp(activemask);
+#endif
       }
+    }
 
     //final flush of output cache
     if ( current_idx_shared[warp_id] > 0 ) 
@@ -439,9 +440,11 @@ const bool predicate = (JoinType::LEFT_JOIN || probe_table.is_row_valid(probe_ro
         
       output_offset = cub::ShuffleIndex(output_offset, 0, warp_size, activemask);
 
-      for ( int shared_out_idx = lane_id; shared_out_idx<current_idx_shared[warp_id]; shared_out_idx+=num_threads ) {
+      for ( int shared_out_idx = lane_id; shared_out_idx<current_idx_shared[warp_id]; shared_out_idx+=num_threads ) 
+      {
         size_type thread_offset = output_offset + shared_out_idx;
-        if (thread_offset < max_size) {
+        if (thread_offset < max_size) 
+        {
           output_l[thread_offset] = join_shared_l[warp_id][shared_out_idx];
           output_r[thread_offset] = join_shared_r[warp_id][shared_out_idx];
         }

--- a/src/tests/join/join-tests.cu
+++ b/src/tests/join/join-tests.cu
@@ -144,7 +144,7 @@ struct JoinTest : public testing::Test
     cudaMemcpy(the_column->data, host_vector.data(), host_vector.size() * sizeof(col_type), cudaMemcpyHostToDevice);
 
     // Allocate device storage for gdf_column.valid
-    int valid_size = gdf::util::valid_size(host_vector.size());
+    int valid_size = gdf_get_num_chars_bitmask(host_vector.size());
     cudaMalloc(&(the_column->valid), valid_size);
     cudaMemcpy(the_column->valid, host_valid, valid_size, cudaMemcpyHostToDevice);
  
@@ -265,7 +265,7 @@ struct JoinTest : public testing::Test
 
     for(size_t right_index = 0; right_index < build_column.size(); ++right_index)
     {
-      if (gdf::util::get_bit(build_valid, right_index)) {
+      if (gdf_is_valid(build_valid, right_index)) {
         the_map.insert(std::make_pair(build_column[right_index], right_index));
       }
     }
@@ -279,7 +279,7 @@ struct JoinTest : public testing::Test
     for(size_t left_index = 0; left_index < probe_column.size(); ++left_index)
     {
       bool match{false};
-      if (gdf::util::get_bit(probe_valid, left_index)) {
+      if (gdf_is_valid(probe_valid, left_index)) {
         // Find all keys that match probe_key
         const auto probe_key = probe_column[left_index];
         auto range = the_map.equal_range(probe_key);

--- a/src/tests/join/valid_vectors.h
+++ b/src/tests/join/valid_vectors.h
@@ -21,6 +21,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <gdf/utils.h>
 
 #include "../../util/bit_util.cuh"
 
@@ -31,7 +32,7 @@ using host_valid_pointer = typename std::unique_ptr<gdf_valid_type, std::functio
 host_valid_pointer create_and_init_valid(size_t length, bool all_bits_on = false)
 {
   auto deleter = [](gdf_valid_type* valid) { delete[] valid; };
-  auto n_bytes = gdf::util::valid_size(length);
+  auto n_bytes = gdf_get_num_chars_bitmask(length);
   auto valid_bits = new gdf_valid_type[n_bytes];
 
   for (size_t i = 0; i < length; ++i) {
@@ -61,7 +62,7 @@ template <typename T>
 void print_vector_and_valid(std::vector<T>& v, gdf_valid_type* valid)
 {
   auto functor = [&valid, &v](int index) -> std::string {
-    if (gdf::util::get_bit(valid, index))
+    if (gdf_is_valid(valid, index))
       return std::to_string((int)v[index]);
     return std::string("@");
   };
@@ -108,7 +109,7 @@ template <std::size_t I = 0, typename... Tp>
 {
   auto l_valid = left_valid[I].get();
   auto r_valid = right_valid[I].get();
-  if (gdf::util::get_bit(l_valid, left_index) && gdf::util::get_bit(r_valid, right_index) && std::get<I>(left)[left_index] == std::get<I>(right)[right_index]) {
+  if (gdf_is_valid(l_valid, left_index) && gdf_is_valid(r_valid, right_index) && std::get<I>(left)[left_index] == std::get<I>(right)[right_index]) {
     return rows_equal_using_valids<I + 1, Tp...>(left, right, left_valid, right_valid, left_index, right_index);
   } else {
     return false;

--- a/src/util/bit_util.cuh
+++ b/src/util/bit_util.cuh
@@ -23,18 +23,21 @@ namespace util {
 static constexpr int ValidSize = 32;
 using ValidType = uint32_t;
 
-__host__ __device__ __forceinline__
-  size_t
-  valid_size(size_t column_length)
-{
-  const size_t n_ints = (column_length / ValidSize) + ((column_length % ValidSize) ? 1 : 0);
-  return n_ints * sizeof(ValidType);
-}
 
-__host__ __device__ __forceinline__ bool get_bit(const gdf_valid_type* const bits, size_t i)
-{
-  return  bits == nullptr? true :  bits[i >> size_t(3)] & (1 << (i & size_t(7)));
-}
+// Instead of this function, use gdf_get_num_chars_bitmask from gdf/utils.h
+//__host__ __device__ __forceinline__
+//  size_t
+//  valid_size(size_t column_length)
+//{
+//  const size_t n_ints = (column_length / ValidSize) + ((column_length % ValidSize) ? 1 : 0);
+//  return n_ints * sizeof(ValidType);
+//}
+
+// Instead of this function, use gdf_is_valid from gdf/utils.h
+///__host__ __device__ __forceinline__ bool get_bit(const gdf_valid_type* const bits, size_t i)
+///{
+///  return  bits == nullptr? true :  bits[i >> size_t(3)] & (1 << (i & size_t(7)));
+///}
 
 __host__ __device__ __forceinline__
   uint8_t


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to libGDF :)

First, if you need some help or want to chat to the core developers, please
visit http://gpuopenanalytics.com/#/COMMUNITY for links to Slack and Google
Groups.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label and replace it with `[REVIEW]` when you'd like it to
   be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

Due to tight time deadlines, this PR finishes what was started by @aocsa in https://github.com/gpuopenanalytics/libgdf/pull/124

Many thanks to @aocsa for all the work he already did that made my work that much easier.

By definition, `NULL != x ∀ x`, therefore, it is impossible for a row with a single `NULL` value to be equal to any other row. As a result, we introduce the concept of a row validity bit-mask that indicates if a row in the table contains even a single `NULL`, in which case the entire row is considered to be invalid. 

The row validity bitmask is constructed by `AND`ing all of the constituent `gdf_column` validity bitmasks together.  This is done in the `gdf_table` constructor.

A new function `gdf_table::is_row_valid(size_type row_index)` was introduced which returns the state of the validity bit corresponding to that row.

The `gdf_table::rows_equal()` function was updated to return false if either row is invalid. This ensures that during the probing phase, an invalid probe row will not match with any row in the hash table.

The `build_hash_table` kernel was updated to check if the row to be inserted into the hash table is `NULL`. If it is `NULL`, then it is not inserted.


