### PR TITLE
[REVIEW] Scatter validity bitmask in gdf-hash_partition

### DIFF
--- a/src/gdf_table.cuh
+++ b/src/gdf_table.cuh
@@ -72,8 +72,49 @@ struct row_masker
   gdf_valid_type ** column_valid_masks;
 };
 
+/* --------------------------------------------------------------------------*/
+/** 
+ * @Synopsis  Scatters a validity bitmask.
+ * 
+ * This kernel is used in order to scatter the validity bit mask for a gdf_column.
+ * 
+ * @Param input_mask The mask that will be scattered.
+ * @Param output_mask The output after scattering the input
+ * @Param scatter_map The map that indicates where elements from the input
+   will be scattered to in the output. output_bit[ scatter_map [i] ] = input_bit[i]
+ * @Param num_rows The number of bits in the masks
+ */
+/* ----------------------------------------------------------------------------*/
+template <typename size_type>
+__global__ 
+void scatter_valid_mask( gdf_valid_type const * const input_mask,
+                         gdf_valid_type * const output_mask,
+                         size_type const * const __restrict__ scatter_map,
+                         size_type const num_rows)
+{
+  using mask_type = uint32_t;
+  constexpr int BITS_PER_MASK = 8 * sizeof(mask_type);
 
+  // Cast the validity type to a type where atomicOr is natively supported
+  const mask_type * __restrict__ input_mask32 = reinterpret_cast<mask_type const *>(input_mask);
+  mask_type * const __restrict__ output_mask32 = reinterpret_cast<mask_type * >(output_mask);
 
+  size_type row_number = threadIdx.x + blockIdx.x * blockDim.x;
+
+  while(row_number < num_rows)
+  {
+    // Get the bit corresponding to the row
+    const mask_type input_bit = input_mask32[row_number/BITS_PER_MASK] & (gdf_valid_type(1) << (row_number % BITS_PER_MASK));
+
+    // Find the mask in the output that will hold the bit for the scattered row
+    const size_type output_location = scatter_map[row_number] / BITS_PER_MASK;
+
+    // Bitwise OR to set the scattered row's bit
+    atomicOr(&output_mask32[output_location], input_bit);
+
+    row_number += blockDim.x * gridDim.x;
+  }
+}
 
 /* --------------------------------------------------------------------------*/
 /** 
@@ -527,6 +568,8 @@ public:
     return hash_value;
   }
 
+
+
 /* --------------------------------------------------------------------------*/
 /** 
  * @brief  Creates a rearrangement of the table into another table by scattering
@@ -551,8 +594,14 @@ gdf_error scatter( gdf_table<size_type> & scattered_output_table,
   // Each column can be scattered in parallel, therefore create a 
   // separate stream for every column
   std::vector<cudaStream_t> column_streams(num_columns);
-  for(auto & s : column_streams)
-  {
+  for(auto & s : column_streams){
+    cudaStreamCreate(&s);
+  }
+
+  // Each columns validity bit mask can be scattered in parallel,
+  // therefore create a separate stream for each column
+  std::vector<cudaStream_t> valid_streams(num_columns);
+  for(auto & s : valid_streams){
     cudaStreamCreate(&s);
   }
 
@@ -566,6 +615,23 @@ gdf_error scatter( gdf_table<size_type> & scattered_output_table,
 
     if(GDF_SUCCESS != gdf_status)
       return gdf_status;
+
+    // If this column has a validity mask, scatter the mask
+    if((nullptr != current_input_column->valid)
+        && (nullptr != current_output_column->valid))
+    {
+      // Ensure the output bitmask is initialized to zero
+      const size_type num_masks = gdf_get_num_chars_bitmask(column_length);
+      cudaMemsetAsync(current_output_column->valid, 0,  num_masks * sizeof(gdf_valid_type), valid_streams[i]);
+
+      // Scatter the validity bits from the input column to output column
+      constexpr int BLOCK_SIZE = 256;
+      const int grid_size = (column_length + BLOCK_SIZE - 1)/BLOCK_SIZE;
+      scatter_valid_mask<<<grid_size, BLOCK_SIZE, 0, valid_streams[i]>>>(current_input_column->valid, 
+                                                                         current_output_column->valid,
+                                                                         row_scatter_map,
+                                                                         column_length);
+    }
 
     // Scatter each column based on it's byte width
     switch(column_width_bytes)
@@ -634,6 +700,11 @@ gdf_error scatter( gdf_table<size_type> & scattered_output_table,
   {
     cudaStreamDestroy(s);
   }
+  // Destroy all streams
+  for(auto & s : valid_streams)
+  {
+    cudaStreamDestroy(s);
+  }
 
   return gdf_status;
 }
@@ -678,6 +749,7 @@ gdf_error scatter_column(column_type const * const __restrict__ input_column,
 
   return gdf_status;
 }
+
 
   const size_type num_columns; /** The number of columns in the table */
   size_type column_length;     /** The number of rows in the table */

--- a/src/gdf_table.cuh
+++ b/src/gdf_table.cuh
@@ -104,7 +104,7 @@ void scatter_valid_mask( gdf_valid_type const * const input_mask,
   while(row_number < num_rows)
   {
     // Get the bit corresponding to the row
-    const mask_type input_bit = input_mask32[row_number/BITS_PER_MASK] & (gdf_valid_type(1) << (row_number % BITS_PER_MASK));
+    const mask_type input_bit = input_mask32[row_number/BITS_PER_MASK] & (mask_type(1) << (row_number % BITS_PER_MASK));
 
     // Find the mask in the output that will hold the bit for the scattered row
     const size_type output_location = scatter_map[row_number] / BITS_PER_MASK;


### PR DESCRIPTION
Implemented a kernel to also scatter the bits in the validity bitmasks when the elements of the columns are permuted in the `gdf_hash_partition` function.

<!--

Thanks for wanting to contribute to libGDF :)

First, if you need some help or want to chat to the core developers, please
visit http://gpuopenanalytics.com/#/COMMUNITY for links to Slack and Google
Groups.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label and replace it with `[REVIEW]` when you'd like it to
   be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
