### PR TITLE
[REVIEW] Explicit cast for atomicAdd operand

### DIFF
--- a/src/hashmap/concurrent_unordered_map.cuh
+++ b/src/hashmap/concurrent_unordered_map.cuh
@@ -437,25 +437,25 @@ public:
     __forceinline__ __host__ __device__
     void update_existing_value(mapped_type & existing_value, value_type const & insert_pair, count_op<int32_t> op)
     {
-      atomicAdd(&existing_value, 1);
+      atomicAdd(&existing_value, static_cast<int32_t>(1));
     }
     // Specialization for COUNT aggregator
     __forceinline__ __host__ __device__
     void update_existing_value(mapped_type & existing_value, value_type const & insert_pair, count_op<int64_t> op)
     {
-      atomicAdd(&existing_value, 1);
+      atomicAdd(&existing_value, static_cast<int64_t>(1));
     }
     // Specialization for COUNT aggregator
     __forceinline__ __host__ __device__
     void update_existing_value(mapped_type & existing_value, value_type const & insert_pair, count_op<float> op)
     {
-      atomicAdd(&existing_value, 1);
+      atomicAdd(&existing_value, static_cast<float>(1));
     }
     // Specialization for COUNT aggregator
     __forceinline__ __host__ __device__
     void update_existing_value(mapped_type & existing_value, value_type const & insert_pair, count_op<double> op)
     {
-      atomicAdd(&existing_value, 1);
+      atomicAdd(&existing_value, static_cast<double>(1));
     }
 
     /* --------------------------------------------------------------------------*/

--- a/src/hashmap/concurrent_unordered_map.cuh
+++ b/src/hashmap/concurrent_unordered_map.cuh
@@ -437,25 +437,25 @@ public:
     __forceinline__ __host__ __device__
     void update_existing_value(mapped_type & existing_value, value_type const & insert_pair, count_op<int32_t> op)
     {
-      atomicAdd(&existing_value, static_cast<int32_t>(1));
+      atomicAdd(&existing_value, static_cast<mapped_type>(1));
     }
     // Specialization for COUNT aggregator
     __forceinline__ __host__ __device__
     void update_existing_value(mapped_type & existing_value, value_type const & insert_pair, count_op<int64_t> op)
     {
-      atomicAdd(&existing_value, static_cast<int64_t>(1));
+      atomicAdd(&existing_value, static_cast<mapped_type>(1));
     }
     // Specialization for COUNT aggregator
     __forceinline__ __host__ __device__
     void update_existing_value(mapped_type & existing_value, value_type const & insert_pair, count_op<float> op)
     {
-      atomicAdd(&existing_value, static_cast<float>(1));
+      atomicAdd(&existing_value, static_cast<mapped_type>(1));
     }
     // Specialization for COUNT aggregator
     __forceinline__ __host__ __device__
     void update_existing_value(mapped_type & existing_value, value_type const & insert_pair, count_op<double> op)
     {
-      atomicAdd(&existing_value, static_cast<double>(1));
+      atomicAdd(&existing_value, static_cast<mapped_type>(1));
     }
 
     /* --------------------------------------------------------------------------*/


### PR DESCRIPTION
Added explicit casts to the value 1 in the atomicAdd that is used for the Count aggregator. 

Without this, there seems to be a compiler error reported by some users.

<!--

Thanks for wanting to contribute to libGDF :)

First, if you need some help or want to chat to the core developers, please
visit http://gpuopenanalytics.com/#/COMMUNITY for links to Slack and Google
Groups.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label and replace it with `[REVIEW]` when you'd like it to
   be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
