### PR TITLE
[WIP] CI update: add cuda version to build string

### DIFF
--- a/conda-recipes/libgdf/meta.yaml
+++ b/conda-recipes/libgdf/meta.yaml
@@ -3,6 +3,7 @@
 # Usage:
 #   conda build -c defaults -c conda-forge .
 {% set cuda_version='.'.join(environ.get('CUDA', 'unknown').split('.')[:2]) %}
+{% set git_revision_count=environ.get('GIT_DESCRIBE_NUMBER', 0) %}
 package:
   name: libgdf
   version: {{ environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') }}
@@ -12,8 +13,8 @@ source:
   path: ../..
 
 build:
-  number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
-  string: cuda_{{ cuda_version }}
+  number: {{ git_revision_count }}
+  string: cuda_{{ cuda_version }}_{{ git_revision_count }}
   script_env:
     - CC
     - CXX

--- a/conda-recipes/libgdf/meta.yaml
+++ b/conda-recipes/libgdf/meta.yaml
@@ -2,6 +2,7 @@
 
 # Usage:
 #   conda build -c defaults -c conda-forge .
+{% set cuda_version='.'.join(environ.get('CUDA', 'unknown').split('.')[:2]) %}
 package:
   name: libgdf
   version: {{ environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') }}
@@ -12,6 +13,7 @@ source:
 
 build:
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
+  string: cuda_{{ cuda_version }}
   script_env:
     - CC
     - CXX


### PR DESCRIPTION
This changes the conda recipe to embed the cuda version used to build the conda packages.  Currently, the TravisCI builder is overwriting packages from different cuda and only the last upload survive.