### PR TITLE
[REVIEW] Optimize gdf_count_nonzero_mask

### DIFF
--- a/src/tests/validops/valids-tests.cu
+++ b/src/tests/validops/valids-tests.cu
@@ -92,11 +92,28 @@ TEST(ValidsTest, 15rows)
   auto input_gdf_col = create_gdf_column(data, valid);
 
   int count{-1};
-  gdf_error error_code = gdf_count_nonzero_mask(input_gdf_col->valid, 15, &count);
+  gdf_error error_code = gdf_count_nonzero_mask(input_gdf_col->valid, num_rows, &count);
 
   ASSERT_EQ(GDF_SUCCESS,error_code) << "GDF Operation did not complete successfully.";
 
   EXPECT_EQ(2, count);
+}
+
+TEST(ValidsTest, 5rows)
+{
+  const int num_rows = 5;
+  std::vector<int> data(num_rows);
+  const int num_masks = std::ceil(num_rows/static_cast<float>(8));
+  std::vector<gdf_valid_type> valid(num_masks,0x01);
+
+  auto input_gdf_col = create_gdf_column(data, valid);
+
+  int count{-1};
+  gdf_error error_code = gdf_count_nonzero_mask(input_gdf_col->valid, num_rows, &count);
+
+  ASSERT_EQ(GDF_SUCCESS,error_code) << "GDF Operation did not complete successfully.";
+
+  EXPECT_EQ(1, count);
 }
 
 TEST(ValidsTest, MultipleOfEight)
@@ -133,6 +150,24 @@ TEST(ValidsTest, NotMultipleOfEight)
   ASSERT_EQ(GDF_SUCCESS,error_code) << "GDF Operation did not complete successfully.";
 
   EXPECT_EQ(127, count);
+}
+
+TEST(ValidsTest, TenThousandRows)
+{
+  const int num_rows = 10000;
+  std::vector<int> data(num_rows);
+
+  const int num_masks = std::ceil(num_rows/static_cast<float>(8));
+  std::vector<gdf_valid_type> valid(num_masks, 0xFF);
+
+  auto input_gdf_col = create_gdf_column(data, valid);
+
+  int count{-1};
+  gdf_error error_code = gdf_count_nonzero_mask(input_gdf_col->valid, num_rows, &count);
+
+  ASSERT_EQ(GDF_SUCCESS,error_code) << "GDF Operation did not complete successfully.";
+
+  EXPECT_EQ(10000, count);
 }
 
 TEST(ValidsTest, PerformanceTest)

--- a/src/tests/validops/valids-tests.cu
+++ b/src/tests/validops/valids-tests.cu
@@ -19,8 +19,9 @@
 #include <gdf/gdf.h>
 #include <gdf/cffi/functions.h>
 #include "../test_utils/gdf_test_utils.cuh"
+#include "cuda_profiler_api.h"
 
-
+#include <chrono>
 TEST(ValidsTest, FirstRowValid)
 {
   std::vector<int> data(4);
@@ -81,12 +82,29 @@ TEST(ValidsTest, OtherEveryOtherBit)
   EXPECT_EQ(4, count);
 }
 
+TEST(ValidsTest, 15rows)
+{
+  const int num_rows = 15;
+  std::vector<int> data(num_rows);
+  const int num_masks = std::ceil(num_rows/static_cast<float>(8));
+  std::vector<gdf_valid_type> valid(num_masks,0x01);
+
+  auto input_gdf_col = create_gdf_column(data, valid);
+
+  int count{-1};
+  gdf_error error_code = gdf_count_nonzero_mask(input_gdf_col->valid, 15, &count);
+
+  ASSERT_EQ(GDF_SUCCESS,error_code) << "GDF Operation did not complete successfully.";
+
+  EXPECT_EQ(2, count);
+}
+
 TEST(ValidsTest, MultipleOfEight)
 {
   const int num_rows = 1024;
   std::vector<int> data(num_rows);
 
-  const int num_masks = std::ceil(num_rows/8);
+  const int num_masks = std::ceil(num_rows/static_cast<float>(8));
   std::vector<gdf_valid_type> valid(num_masks,0x01);
 
   auto input_gdf_col = create_gdf_column(data, valid);
@@ -104,8 +122,8 @@ TEST(ValidsTest, NotMultipleOfEight)
   const int num_rows = 1023;
   std::vector<int> data(num_rows);
 
-  const int num_masks = std::ceil(num_rows/8);
-  std::vector<gdf_valid_type> valid(num_masks, 0x01);
+  const int num_masks = std::ceil(num_rows/static_cast<float>(8));
+  std::vector<gdf_valid_type> valid(num_masks, 0x80);
 
   auto input_gdf_col = create_gdf_column(data, valid);
 
@@ -115,6 +133,28 @@ TEST(ValidsTest, NotMultipleOfEight)
   ASSERT_EQ(GDF_SUCCESS,error_code) << "GDF Operation did not complete successfully.";
 
   EXPECT_EQ(127, count);
+}
+
+TEST(ValidsTest, PerformanceTest)
+{
+  const int num_rows = 100000000;
+  std::vector<int> data(num_rows);
+
+  const int num_masks = std::ceil(num_rows/8);
+  std::vector<gdf_valid_type> valid(num_masks, 0x55);
+
+  auto input_gdf_col = create_gdf_column(data, valid);
+
+  int count{-1};
+  
+  auto start = std::chrono::system_clock::now();
+  cudaProfilerStart();
+  for(int i = 0; i < 1000; ++i)
+    gdf_error error_code = gdf_count_nonzero_mask(input_gdf_col->valid, num_rows, &count);
+  cudaProfilerStop();
+  auto end = std::chrono::system_clock::now();
+  std::chrono::duration<double> elapsed_seconds = end-start;
+  std::cout << "Elapsed time (ms): " << elapsed_seconds.count()*1000 << std::endl;
 }
 
 

--- a/src/validops.cu
+++ b/src/validops.cu
@@ -2,9 +2,8 @@
 #include <gdf/errorutils.h>
 #include <gdf/utils.h>
 #include <vector>
-#include <thrust/device_ptr.h>
-#include <thrust/transform_reduce.h>
-#include <thrust/functional.h>
+#include <cassert>
+#include <cub/cub.cuh>
 
 
 using valid32_t = uint32_t;
@@ -13,6 +12,8 @@ using valid32_t = uint32_t;
 // compute the RATIO of the number of bytes in gdf_valid_type
 // to the 4 byte type being used for casting
 constexpr size_t RATIO = sizeof(valid32_t) / sizeof(gdf_valid_type);
+
+constexpr int block_size = 256;
 
 /* --------------------------------------------------------------------------*/
 /** 
@@ -61,6 +62,29 @@ size_t count_valid_bits_host(std::vector<gdf_valid_type> const & masks, const in
   return count;
 }
 
+
+__global__ 
+void count_valid_bits(valid32_t const * const __restrict__ masks32, const int num_masks32, int * const __restrict__ global_count)
+{
+  typedef cub::BlockReduce<int, block_size> BlockReduce;
+  __shared__ typename BlockReduce::TempStorage temp_storage;
+
+  int cur_mask = threadIdx.x + blockIdx.x * gridDim.x;
+
+  int my_count = 0;
+  while(cur_mask < num_masks32)
+  {
+    my_count += __popc(masks32[cur_mask]);
+
+    cur_mask += blockDim.x * gridDim.x;
+  }
+
+  int block_count = BlockReduce(temp_storage).Sum(my_count);
+
+  if(threadIdx.x == 0)
+    atomicAdd(global_count, block_count);
+}
+
 /* --------------------------------------------------------------------------*/
 /** 
  * @Synopsis  Counts the number of valid bits for the specified number of rows
@@ -76,6 +100,9 @@ size_t count_valid_bits_host(std::vector<gdf_valid_type> const & masks, const in
 gdf_error gdf_count_nonzero_mask(gdf_valid_type const * masks, int num_rows, int * count)
 {
 
+  // Why am I getting an unused function warning error if I don't do this?
+  gdf_is_valid(nullptr, 0);
+
   if((nullptr == masks) || (nullptr == count)){return GDF_DATASET_EMPTY;}
   if(0 == num_rows) {return GDF_SUCCESS;}
 
@@ -85,52 +112,54 @@ gdf_error gdf_count_nonzero_mask(gdf_valid_type const * masks, int num_rows, int
   const size_t num_masks = gdf_get_num_chars_bitmask(num_rows);
 
   // Number of 4 byte types in the validity bit mask 
-  const size_t num_masks32 = num_masks / RATIO;
+  size_t num_masks32 = num_masks / RATIO;
 
   // If the total number of masks is not a multiple of the RATIO 
   // between the original mask type and the 4 byte masks type, then 
   // these "remainder" masks cannot be proccessed in the transform_reduce
   // and must be handled separately
   cudaStream_t copy_stream;
-  const size_t num_remainder_masks = num_masks % RATIO;
+  size_t num_remainder_masks = num_masks % RATIO;
+
+  // If there are no remainder masks, the last mask still
+  // needs to be handled separately
+  if(0 == num_remainder_masks){
+    num_remainder_masks = RATIO;
+    num_masks32--;
+  }
+
   std::vector<gdf_valid_type> remainder_masks(num_remainder_masks); 
   if(remainder_masks.size() > 0)
   {
-
     CUDA_TRY(cudaStreamCreate(&copy_stream));
 
     // Copy the remainder masks to the host
     // FIXME: Is this endian safe?
-    const gdf_valid_type * first_remainder_mask = (masks + num_masks) - num_remainder_masks;
+    const gdf_valid_type * first_remainder_mask = &(masks[num_masks - num_remainder_masks]);
+
     CUDA_TRY( cudaMemcpyAsync(remainder_masks.data(), 
                               first_remainder_mask, 
                               num_remainder_masks * sizeof(gdf_valid_type), 
-                              cudaMemcpyDeviceToHost, 
+                              cudaMemcpyDeviceToHost,
                               copy_stream) );
   }
 
-
-  // Device lambda to count the number of valid bits in each mask
-  auto mask_bit_counter = [] __device__ (valid32_t const mask)
+  int * d_count32;
+  cudaStream_t count_stream;
+  if(num_masks32 > 0)
   {
-    // TODO What type will Thrust use for the temporary storage
-    // during the transform_reduce? We could store this result in
-    // an int8_t, but the reduction would overflow an int8_t accumulator
-    return __popc(mask);
-  };
+    CUDA_TRY(cudaStreamCreate(&count_stream));
+    // Cast validity buffer to 4 byte type
+    valid32_t const * masks32 = reinterpret_cast<valid32_t const *>(masks);
 
-  // Cast validity buffer to 4 byte type
-  thrust::device_ptr<valid32_t const> masks32 = thrust::device_pointer_cast(reinterpret_cast<valid32_t const *>(masks));
+    CUDA_TRY(cudaMalloc(&d_count32, sizeof(int)));
+    CUDA_TRY(cudaMemsetAsync(d_count32, 0, sizeof(int),count_stream));
 
-  // Count the number of valid bits in all the masks that are a 
-  // multiple of 4 bytes
-  const size_t count32 = thrust::transform_reduce(masks32,
-                                                  masks32 + num_masks32,
-                                                  mask_bit_counter,
-                                                  0,
-                                                  thrust::plus<int>());
+    const int grid_size = (num_masks32 + block_size - 1)/block_size;
+    count_valid_bits<<<grid_size, block_size,0,count_stream>>>(masks32, num_masks32, d_count32);
 
-  CUDA_TRY( cudaGetLastError() );
+    CUDA_TRY( cudaGetLastError() );
+  }
 
   // Count the number of valid bits in the remainder masks
   size_t remainder_count = 0;
@@ -139,6 +168,14 @@ gdf_error gdf_count_nonzero_mask(gdf_valid_type const * masks, int num_rows, int
     CUDA_TRY(cudaStreamSynchronize(copy_stream));
     CUDA_TRY(cudaStreamDestroy(copy_stream));
     remainder_count = count_valid_bits_host(remainder_masks, num_rows);
+  }
+
+  int count32{0};
+  if(num_masks32 > 0)
+  {
+    CUDA_TRY(cudaMemcpyAsync(&count32, d_count32, sizeof(int), cudaMemcpyDeviceToHost,count_stream));
+    CUDA_TRY(cudaStreamSynchronize(count_stream));
+    CUDA_TRY(cudaStreamDestroy(count_stream));
   }
 
   // The final count of valid bits is the sum of the result from the

--- a/src/validops.cu
+++ b/src/validops.cu
@@ -71,7 +71,7 @@ void count_valid_bits(valid32_t const * const __restrict__ masks32,
                       int * const __restrict__ global_count)
 {
 
-  const int cur_mask = threadIdx.x + blockIdx.x * blockDim.x;
+  int cur_mask = threadIdx.x + blockIdx.x * blockDim.x;
 
   typedef cub::BlockReduce<int, block_size> BlockReduce;
   __shared__ typename BlockReduce::TempStorage temp_storage;


### PR DESCRIPTION


<!--

Thanks for wanting to contribute to libGDF :)

First, if you need some help or want to chat to the core developers, please
visit http://gpuopenanalytics.com/#/COMMUNITY for links to Slack and Google
Groups.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label and replace it with `[REVIEW]` when you'd like it to
   be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

This function improves the performance of gdf_count_nonzero_mask by using a custom kernel instead of using thrust's transform reduction, which incurred surprising overheads due to cudaFuncGetAttributes.
